### PR TITLE
Return KeysView objects from ItemAdapter.field_names

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ for `scrapy.item.Item`s
 * [`attr.Attribute.metadata`](https://www.attrs.org/en/stable/examples.html#metadata)
   for `attrs`-based items
 
-`field_names() -> List[str]`
+`field_names() -> KeysView`
 
-Return a list with the names of all the defined fields for the item.
+Return a [keys view](https://docs.python.org/3/library/collections.abc.html#collections.abc.KeysView)
+with the names of all the defined fields for the item.
 
 ### `is_item` function
 

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -1,6 +1,6 @@
-from collections.abc import MutableMapping
+from collections.abc import KeysView, MutableMapping
 from types import MappingProxyType
-from typing import Any, Iterator, List
+from typing import Any, Iterator, Optional
 
 from .utils import is_item, is_attrs_instance, is_dataclass_instance, is_scrapy_item
 
@@ -15,6 +15,7 @@ class ItemAdapter(MutableMapping):
         if not is_item(item):
             raise TypeError("Expected a valid item, got %r instead: %s" % (type(item), item))
         self.item = item
+        self._fields_dict = None  # type: Optional[dict]
 
     def __repr__(self) -> str:
         return "ItemAdapter for type %s: %r" % (self.item.__class__.__name__, self.item)
@@ -98,19 +99,25 @@ class ItemAdapter(MutableMapping):
         else:
             return MappingProxyType({})
 
-    def field_names(self) -> List[str]:
+    def field_names(self) -> KeysView:
         """
-        Return a list with the names of all the defined fields for the item
+        Return read-only key view with the names of all the defined fields for the item
         """
         if is_scrapy_item(self.item):
-            return list(self.item.fields.keys())
+            return KeysView(self.item.fields)
         elif is_dataclass_instance(self.item):
             import dataclasses
 
-            return [field.name for field in dataclasses.fields(self.item)]
+            if self._fields_dict is None:
+                self._fields_dict = {field.name: None for field in dataclasses.fields(self.item)}
+            return KeysView(self._fields_dict)
         elif is_attrs_instance(self.item):
             import attr
 
-            return [field.name for field in attr.fields(self.item.__class__)]
+            if self._fields_dict is None:
+                self._fields_dict = {
+                    field.name: None for field in attr.fields(self.item.__class__)
+                }
+            return KeysView(self._fields_dict)
         else:
-            return list(self.item.keys())
+            return KeysView(self.item)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,5 +1,6 @@
 import unittest
 from types import MappingProxyType
+from typing import KeysView
 
 from itemadapter.adapter import ItemAdapter
 
@@ -89,7 +90,7 @@ class BaseTestMixin:
     def test_field_names(self):
         item = self.item_class(name="asdf", value=1234)
         adapter = ItemAdapter(item)
-        self.assertIsInstance(adapter.field_names(), list)
+        self.assertIsInstance(adapter.field_names(), KeysView)
         self.assertEqual(sorted(adapter.field_names()), ["name", "value"])
 
 
@@ -148,6 +149,13 @@ class DictTestCase(unittest.TestCase, BaseTestMixin):
         adapter = ItemAdapter(self.item_class(name="foo", value=5))
         for field_name in ("name", "value", "undefined_field"):
             self.assertEqual(adapter.get_field_meta(field_name), MappingProxyType({}))
+
+    def test_field_names_updated(self):
+        item = self.item_class(name="asdf")
+        field_names = ItemAdapter(item).field_names()
+        self.assertEqual(sorted(field_names), ["name"])
+        item["value"] = 1234
+        self.assertEqual(sorted(field_names), ["name", "value"])
 
 
 class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,flake8,typing,black
+envlist = flake8,typing,black,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
Fixes #2

~I'm not sure dataclass and attrs items actually benefit from this, but the change is probably justified just for dicts and items.
Assuming `attr.fields_dict` gets the fields in an efficient way instead of scanning the class attributes (which I don't know), the dataclasses case is definitely not gaining in performance, since it's creating a new dict every time.~

Let me know what you think @kmike 

**Update:** Looking at the [upstream implementation](https://github.com/python/cpython/blob/v3.8.3/Lib/_collections_abc.py#L694-L720), `KeysView` is basically a wrapper that keeps a reference to the original mapping. I'm creating a mapping for `dataclass` and `attrs` items, using `None` as value to save memory since the value is not important. This should be safe, because neither type allows to add new fields to existing objects.