### PR TITLE
Raise custom exception instead of TypeError in get_field_meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Two additional methods are available:
 `get_field_meta(field_name: str) -> MappingProxyType`
 
 Return a [`MappingProxyType`](https://docs.python.org/3/library/types.html#types.MappingProxyType)
-object with metadata about the given field, or raise `TypeError` if the item class does not
-support field metadata.
+object with metadata about the given field, or raise `itemadapter.exceptions.NoMetadataSupport`
+if the item class does not support field metadata.
 
 The returned value is taken from the following sources, depending on the item type:
 
@@ -126,6 +126,14 @@ for `scrapy.item.Item`s
 `field_names() -> List[str]`
 
 Return a list with the names of all the defined fields for the item.
+
+
+### `NoMetadataSupport` exception
+
+_`itemadapter.exceptions.NoMetadataSupport(TypeError)`_
+
+Raised when `ItemAdapter.get_field_meta` is called on an item that does not support metadata.
+
 
 ### `is_item` function
 

--- a/itemadapter/__init__.py
+++ b/itemadapter/__init__.py
@@ -1,4 +1,5 @@
 from .adapter import ItemAdapter  # noqa: F401
+from .exceptions import NoMetadataSupport  # noqa: F401
 from .utils import is_item  # noqa: F401
 
 

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -2,6 +2,7 @@ from collections.abc import MutableMapping
 from types import MappingProxyType
 from typing import Any, Iterator, List
 
+from .exceptions import NoMetadataSupport
 from .utils import is_item, is_attrs_instance, is_dataclass_instance, is_scrapy_item
 
 
@@ -72,6 +73,8 @@ class ItemAdapter(MutableMapping):
 
         The returned value is an instance of types.MappingProxyType, i.e. a dynamic read-only view
         of the original mapping, which gets automatically updated if the original mapping changes.
+
+        If the wrapped item does not support metadata, NoMetadataSupport is raised.
         """
         if is_dataclass_instance(self.item):
             from dataclasses import fields
@@ -94,7 +97,9 @@ class ItemAdapter(MutableMapping):
         elif is_scrapy_item(self.item):
             return MappingProxyType(self.item.fields[field_name])
         else:
-            raise TypeError("Item of type %r does not support field metadata" % type(self.item))
+            raise NoMetadataSupport(
+                "Item of type %r does not support field metadata" % type(self.item)
+            )
 
     def field_names(self) -> List[str]:
         """

--- a/itemadapter/exceptions.py
+++ b/itemadapter/exceptions.py
@@ -1,0 +1,5 @@
+class NoMetadataSupport(TypeError):
+    """
+    Raised when ItemAdapter.get_field_meta is called
+    on an item that does not support metadata.
+    """

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -6,6 +6,7 @@ import attr
 from scrapy.item import Item, Field
 
 from itemadapter.adapter import ItemAdapter
+from itemadapter.exceptions import NoMetadataSupport
 
 
 try:
@@ -171,11 +172,11 @@ class MetadataTestCase(unittest.TestCase):
 
     def test_meta_dict(self):
         adapter = ItemAdapter(dict(name="foo", value=5))
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NoMetadataSupport):
             adapter.get_field_meta("name")
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NoMetadataSupport):
             adapter.get_field_meta("value")
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NoMetadataSupport):
             adapter.get_field_meta("undefined_field")
 
     def test_get_field_meta_defined_fields(self):


### PR DESCRIPTION
Fixes #6

I changed my mind about what I said in https://github.com/scrapy/scrapy/pull/3881#discussion_r428301072, I'd prefer to keep a consistent return type in `get_field_meta`, which won't happen if we add a `default` parameter.