### PR TITLE
Tox env with no dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      run: tox -e py
+      run: tox -e py${{ matrix.python-version }}
 
     - name: Upload coverage report
       run: bash <(curl -s https://codecov.io/bash) -cF tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   checks:
-    name: Lint, typing, coverage
+    name: Flake8, typing, black
     runs-on: ubuntu-latest
 
     steps:
@@ -27,12 +27,6 @@ jobs:
     - name: Black
       run: tox -e black
 
-    - name: Generate coverage report
-      run: tox -e py
-
-    - name: Upload coverage report
-      run: bash <(curl -s https://codecov.io/bash)
-
 
   tests-ubuntu:
     name: "Test: py${{ matrix.python-version }}, Ubuntu"
@@ -54,6 +48,32 @@ jobs:
 
     - name: Run tests
       run: tox -e py
+
+    - name: Upload coverage report
+      run: bash <(curl -s https://codecov.io/bash) -cF tests
+
+
+  tests-no-deps:
+    name: "Test: python3.6, Ubuntu, no deps"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+
+    - name: Install tox
+      run: pip install tox
+
+    - name: Run tests
+      run: tox -e no-deps
+
+    - name: Upload coverage report
+      run: bash <(curl -s https://codecov.io/bash) -cF tests
+
 
   tests-other-os:
     name: "Test: py3.8, ${{ matrix.os }}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,0 @@
-attrs
-dataclasses; python_version == "3.6"
-pytest-cov>=2.8
-pytest>=5.4
-scrapy>=2.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,6 @@ from itemadapter.utils import is_item, is_attrs_instance, is_dataclass_instance,
 from tests import AttrsItem, DataClassItem, ScrapyItem, ScrapySubclassedItem
 
 
-def mocked_import(name, *args, **kwargs):
-    raise ImportError(name)
-
-
 class ItemLikeTestCase(unittest.TestCase):
     def test_false(self):
         self.assertFalse(is_item(int))
@@ -50,8 +46,6 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(is_attrs_instance(sum))
         self.assertFalse(is_attrs_instance(1234))
         self.assertFalse(is_attrs_instance(object()))
-        self.assertFalse(is_attrs_instance(ScrapyItem()))
-        self.assertFalse(is_attrs_instance(ScrapySubclassedItem()))
         self.assertFalse(is_attrs_instance("a string"))
         self.assertFalse(is_attrs_instance(b"some bytes"))
         self.assertFalse(is_attrs_instance({"a": "dict"}))
@@ -59,11 +53,6 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(is_attrs_instance(("a", "tuple")))
         self.assertFalse(is_attrs_instance({"a", "set"}))
         self.assertFalse(is_attrs_instance(AttrsItem))
-
-    @unittest.skipIf(not AttrsItem, "attrs module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
-    def test_module_not_available(self):
-        self.assertFalse(is_attrs_instance(AttrsItem(name="asdf", value=1234)))
 
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
     def test_true(self):
@@ -77,9 +66,6 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(is_dataclass_instance(sum))
         self.assertFalse(is_dataclass_instance(1234))
         self.assertFalse(is_dataclass_instance(object()))
-        self.assertFalse(is_dataclass_instance(ScrapyItem()))
-        self.assertFalse(is_dataclass_instance(AttrsItem()))
-        self.assertFalse(is_dataclass_instance(ScrapySubclassedItem()))
         self.assertFalse(is_dataclass_instance("a string"))
         self.assertFalse(is_dataclass_instance(b"some bytes"))
         self.assertFalse(is_dataclass_instance({"a": "dict"}))
@@ -87,11 +73,6 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(is_dataclass_instance(("a", "tuple")))
         self.assertFalse(is_dataclass_instance({"a", "set"}))
         self.assertFalse(is_dataclass_instance(DataClassItem))
-
-    @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
-    def test_module_not_available(self):
-        self.assertFalse(is_dataclass_instance(DataClassItem(name="asdf", value=1234)))
 
     @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
     def test_true(self):
@@ -105,7 +86,6 @@ class ScrapyItemTestCase(unittest.TestCase):
         self.assertFalse(is_scrapy_item(sum))
         self.assertFalse(is_scrapy_item(1234))
         self.assertFalse(is_scrapy_item(object()))
-        self.assertFalse(is_scrapy_item(AttrsItem()))
         self.assertFalse(is_scrapy_item("a string"))
         self.assertFalse(is_scrapy_item(b"some bytes"))
         self.assertFalse(is_scrapy_item({"a": "dict"}))
@@ -113,11 +93,6 @@ class ScrapyItemTestCase(unittest.TestCase):
         self.assertFalse(is_scrapy_item(("a", "tuple")))
         self.assertFalse(is_scrapy_item({"a", "set"}))
         self.assertFalse(is_scrapy_item(ScrapySubclassedItem))
-
-    @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
-    def test_module_not_available(self):
-        self.assertFalse(is_scrapy_item(ScrapySubclassedItem(name="asdf", value=1234)))
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
     def test_true(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,typing,black,py35,py36,py37,py38,no-deps
+envlist = flake8,typing,black,py3.5,py3.6,py3.7,py3.8,no-deps
 
 [testenv]
 deps =
@@ -8,14 +8,14 @@ deps =
 commands =
     pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --cov-append {posargs: itemadapter tests}
 
-[testenv:py35]
+[testenv:py3.5]
 basepython = python3.5
 deps =
     {[testenv]deps}
     attrs
     scrapy>=2.0
 
-[testenv:py36]
+[testenv:py3.6]
 basepython = python3.6
 deps =
     {[testenv]deps}
@@ -23,14 +23,14 @@ deps =
     dataclasses
     scrapy>=2.0
 
-[testenv:py37]
+[testenv:py3.7]
 basepython = python3.7
 deps =
     {[testenv]deps}
     attrs
     scrapy>=2.0
 
-[testenv:py38]
+[testenv:py3.8]
 basepython = python3.8
 deps =
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,46 @@
 [tox]
-envlist = py35,py36,py37,py38,flake8,typing,black
+envlist = py35,py36,py37,py38,no-deps,flake8,typing,black
 
 [testenv]
 deps =
-    -rtests/requirements.txt
+    pytest>=5.4
+    pytest-cov>=2.8
 commands =
-    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: itemadapter tests}
+    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --cov-append {posargs: itemadapter tests}
 
 [testenv:py35]
 basepython = python3.5
+deps =
+    {[testenv]deps}
+    attrs
+    scrapy>=2.0
 
 [testenv:py36]
 basepython = python3.6
+deps =
+    {[testenv]deps}
+    attrs
+    dataclasses
+    scrapy>=2.0
 
 [testenv:py37]
 basepython = python3.7
+deps =
+    {[testenv]deps}
+    attrs
+    scrapy>=2.0
 
 [testenv:py38]
 basepython = python3.8
+deps =
+    {[testenv]deps}
+    attrs
+    scrapy>=2.0
+
+[testenv:no-deps]
+deps =
+    {[testenv]deps}
+basepython = python3.6
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
Fixes #10

Two problems with this:
* ~[Merging reports](https://docs.codecov.io/docs/merging-reports) does not seem to be working, coverage report shows a 13.9% decrease that is not actually accurate.~
* `attrs` is a [dependency of pytest](https://github.com/pytest-dev/pytest/blob/5.4.2/setup.py#L8), so it gets installed. I tried to mock it but it's tricky, we need to prevent all imports from within `itemadapter` but not those within `pytest`; not sure it's worth it.