### PR TITLE
ItemAdapter.asdict (recursive dict conversion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,12 @@ True
 
 ### Converting to dict
 
-The simple way: passing an `ItemAdapter` to the `dict` built-in will create a new dictionary:
-
-```python
->>> dict(adapter)
-{'name': 'bar', 'price': 12.7, 'stock': 9}
-```
-
-However, this doesn't work for nested items. In those cases, you could use the
-`ItemAdapter.asdict` method. Consider the following example:
+The `ItemAdapter` class provides the `asdict` method, which also converts
+nested items recursively. Consider the following example:
 
 ```python
 from dataclasses import dataclass
+from itemadapter import ItemAdapter
 
 @dataclass
 class Price:
@@ -109,17 +103,19 @@ class Product:
 ```
 
 ```python
->>> item = Product("Stuff", Price(50, "UYU"))
+>>> item = Product("Stuff", Price(42, "UYU"))
 >>> adapter = ItemAdapter(item)
-
->>> dict(adapter)  # not recursive
-{'name': 'Stuff', 'price': Price(value=50, currency='UYU')}
-
->>> adapter.asdict()  # recursive
-{'name': 'Stuff', 'price': {'currency': 'UYU', 'value': 50}}
+>>> adapter.asdict()
+{'name': 'Stuff', 'price': {'currency': 'UYU', 'value': 42}}
 ```
 
-For more examples using different types, refer to the [examples section](#more-examples) below.
+Note that just passing an adapter object to the `dict` built-in also works,
+but it doesn't traverse the object recursively converting nested items:
+
+```python
+>>> dict(adapter)
+{'name': 'Stuff', 'price': Price(value=42, currency='UYU')}
+```
 
 
 ## Public API

--- a/README.md
+++ b/README.md
@@ -82,13 +82,41 @@ InventoryItem(name='bar', price=12.7, stock=9)
 True
 ```
 
-### Converting to dictionary
+### Converting to dict
 
-Passing an `ItemAdapter` to the `dict` built-in will create a new dictionary:
+The simple way: passing an `ItemAdapter` to the `dict` built-in will create a new dictionary:
 
 ```python
 >>> dict(adapter)
 {'name': 'bar', 'price': 12.7, 'stock': 9}
+```
+
+However, this doesn't work for nested items. In those cases, you could use the
+`ItemAdapter.asdict` method. Consider the following example:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class Price:
+    value: int
+    currency: str
+
+@dataclass
+class Product:
+    name: str
+    price: Price
+```
+
+```python
+>>> item = Product("Stuff", Price(50, "UYU"))
+>>> adapter = ItemAdapter(item)
+
+>>> dict(adapter)  # not recursive
+{'name': 'Stuff', 'price': Price(value=50, currency='UYU')}
+
+>>> adapter.asdict()  # recursive
+{'name': 'Stuff', 'price': {'currency': 'UYU', 'value': 50}}
 ```
 
 For more examples using different types, refer to the [examples section](#more-examples) below.
@@ -105,7 +133,7 @@ _class `itemadapter.adapter.ItemAdapter(item: Any)`_
 providing a `dict`-like API to manipulate data for the object it wraps
 (which is modified in-place).
 
-Two additional methods are available:
+Some additional methods are available:
 
 `get_field_meta(field_name: str) -> MappingProxyType`
 
@@ -126,6 +154,11 @@ for `scrapy.item.Item`s
 
 Return a [keys view](https://docs.python.org/3/library/collections.abc.html#collections.abc.KeysView)
 with the names of all the defined fields for the item.
+
+`asdict() -> dict`
+
+Return a dict object with the contents of the adapter. This works slightly different than
+calling `dict(adapter)`, because it's applied recursively to nested items (if there are any).
 
 ### `is_item` function
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ True
 
 ### Converting to dict
 
-The `ItemAdapter` class provides the `asdict` method, which also converts
+The `ItemAdapter` class provides the `asdict` method, which converts
 nested items recursively. Consider the following example:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ with the names of all the defined fields for the item.
 
 `asdict() -> dict`
 
-Return a dict object with the contents of the adapter. This works slightly different than
+Return a `dict` object with the contents of the adapter. This works slightly different than
 calling `dict(adapter)`, because it's applied recursively to nested items (if there are any).
 
 ### `is_item` function

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -134,11 +134,13 @@ def _asdict(obj: Any) -> Any:
     """
     Helper for ItemAdapter.asdict
     """
-    if isinstance(obj, ItemAdapter):
+    if isinstance(obj, dict):
+        return {key: _asdict(value) for key, value in obj.items()}
+    elif isinstance(obj, (list, set, tuple)):
+        return obj.__class__(_asdict(x) for x in obj)
+    elif isinstance(obj, ItemAdapter):
         return obj.asdict()
     elif is_item(obj):
         return ItemAdapter(obj).asdict()
-    elif isinstance(obj, (list, set, tuple)):
-        return obj.__class__(_asdict(x) for x in obj)
     else:
         return obj

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -121,3 +121,24 @@ class ItemAdapter(MutableMapping):
             return KeysView(self._fields_dict)
         else:
             return KeysView(self.item)
+
+    def asdict(self) -> dict:
+        """
+        Return a dict object with the contents of the adapter. This works slightly different than
+        calling `dict(adapter)`: it's applied recursively to nested items (if there are any).
+        """
+        return {key: _asdict(value) for key, value in self.items()}
+
+
+def _asdict(obj: Any) -> Any:
+    """
+    Helper for ItemAdapter.asdict
+    """
+    if isinstance(obj, ItemAdapter):
+        return obj.asdict()
+    elif is_item(obj):
+        return ItemAdapter(obj).asdict()
+    elif isinstance(obj, (list, set, tuple)):
+        return obj.__class__(_asdict(x) for x in obj)
+    else:
+        return obj

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,11 @@
+from itemadapter.adapter import ItemAdapter
+
+
 try:
     import attr
 except ImportError:
     AttrsItem = None
+    AttrsItemNested = None
 else:
 
     @attr.s
@@ -9,11 +13,21 @@ else:
         name = attr.ib(default=None, metadata={"serializer": str})
         value = attr.ib(default=None, metadata={"serializer": int})
 
+    @attr.s
+    class AttrsItemNested:
+        nested = attr.ib(type=AttrsItem)
+        adapter = attr.ib(type=ItemAdapter)
+        list_ = attr.ib(type=list)
+        set_ = attr.ib(type=set)
+        tuple_ = attr.ib(type=tuple)
+        int_ = attr.ib(type=int)
+
 
 try:
     from dataclasses import make_dataclass, field
 except ImportError:
     DataClassItem = None
+    DataClassItemNested = None
 else:
     DataClassItem = make_dataclass(
         "DataClassItem",
@@ -23,14 +37,35 @@ else:
         ],
     )
 
+    DataClassItemNested = make_dataclass(
+        "DataClassItem",
+        [
+            ("nested", DataClassItem),
+            ("adapter", ItemAdapter),
+            ("list_", list),
+            ("set_", set),
+            ("tuple_", tuple),
+            ("int_", int),
+        ],
+    )
+
 
 try:
     from scrapy.item import Item as ScrapyItem, Field
 except ImportError:
     ScrapyItem = None
     ScrapySubclassedItem = None
+    ScrapySubclassedItemNested = None
 else:
 
     class ScrapySubclassedItem(ScrapyItem):
         name = Field(serializer=str)
         value = Field(serializer=int)
+
+    class ScrapySubclassedItemNested(ScrapyItem):
+        nested = Field()
+        adapter = Field()
+        list_ = Field()
+        set_ = Field()
+        tuple_ = Field()
+        int_ = Field()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,6 +17,7 @@ else:
     class AttrsItemNested:
         nested = attr.ib(type=AttrsItem)
         adapter = attr.ib(type=ItemAdapter)
+        dict_ = attr.ib(type=dict)
         list_ = attr.ib(type=list)
         set_ = attr.ib(type=set)
         tuple_ = attr.ib(type=tuple)
@@ -42,6 +43,7 @@ else:
         [
             ("nested", DataClassItem),
             ("adapter", ItemAdapter),
+            ("dict_", dict),
             ("list_", list),
             ("set_", set),
             ("tuple_", tuple),
@@ -65,6 +67,7 @@ else:
     class ScrapySubclassedItemNested(ScrapyItem):
         nested = Field()
         adapter = Field()
+        dict_ = Field()
         list_ = Field()
         set_ = Field()
         tuple_ = Field()

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -4,7 +4,14 @@ from typing import KeysView
 
 from itemadapter.adapter import ItemAdapter
 
-from tests import AttrsItem, DataClassItem, ScrapySubclassedItem
+from tests import (
+    AttrsItem,
+    AttrsItemNested,
+    DataClassItem,
+    DataClassItemNested,
+    ScrapySubclassedItem,
+    ScrapySubclassedItemNested,
+)
 
 
 class ItemAdapterReprTestCase(unittest.TestCase):
@@ -52,6 +59,7 @@ class ItemAdapterInitError(unittest.TestCase):
 class BaseTestMixin:
 
     item_class = None
+    item_class_nested = None
 
     def setUp(self):
         if self.item_class is None:
@@ -86,6 +94,28 @@ class BaseTestMixin:
         item = self.item_class(name="asdf", value=1234)
         adapter = ItemAdapter(item)
         self.assertEqual(dict(name="asdf", value=1234), dict(adapter))
+
+    def test_as_dict_nested(self):
+        item = self.item_class_nested(
+            nested=self.item_class(name="asdf", value=1234),
+            adapter=ItemAdapter(dict(foo="bar", nested_list=[1, 2, 3, 4, 5])),
+            list_=[1, 2, 3],
+            set_={1, 2, 3},
+            tuple_=(1, 2, 3),
+            int_=123,
+        )
+        adapter = ItemAdapter(item)
+        self.assertEqual(
+            adapter.asdict(),
+            dict(
+                nested=dict(name="asdf", value=1234),
+                adapter=dict(foo="bar", nested_list=[1, 2, 3, 4, 5]),
+                list_=[1, 2, 3],
+                set_={1, 2, 3},
+                tuple_=(1, 2, 3),
+                int_=123,
+            ),
+        )
 
     def test_field_names(self):
         item = self.item_class(name="asdf", value=1234)
@@ -138,6 +168,7 @@ class NonDictTestMixin(BaseTestMixin):
 class DictTestCase(unittest.TestCase, BaseTestMixin):
 
     item_class = dict
+    item_class_nested = dict
 
     def test_get_value_keyerror_item_dict(self):
         """Instantiate without default values"""
@@ -161,6 +192,7 @@ class DictTestCase(unittest.TestCase, BaseTestMixin):
 class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = ScrapySubclassedItem
+    item_class_nested = ScrapySubclassedItemNested
 
     def test_get_value_keyerror_item_dict(self):
         """Instantiate without default values"""
@@ -172,8 +204,10 @@ class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
 class DataClassItemTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = DataClassItem
+    item_class_nested = DataClassItemNested
 
 
 class AttrsItemTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = AttrsItem
+    item_class_nested = AttrsItemNested

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -99,6 +99,7 @@ class BaseTestMixin:
         item = self.item_class_nested(
             nested=self.item_class(name="asdf", value=1234),
             adapter=ItemAdapter(dict(foo="bar", nested_list=[1, 2, 3, 4, 5])),
+            dict_={"foo": "bar", "answer": 42, "nested_dict": {"a": "b"}},
             list_=[1, 2, 3],
             set_={1, 2, 3},
             tuple_=(1, 2, 3),
@@ -110,6 +111,7 @@ class BaseTestMixin:
             dict(
                 nested=dict(name="asdf", value=1234),
                 adapter=dict(foo="bar", nested_list=[1, 2, 3, 4, 5]),
+                dict_={"foo": "bar", "answer": 42, "nested_dict": {"a": "b"}},
                 list_=[1, 2, 3],
                 set_={1, 2, 3},
                 tuple_=(1, 2, 3),


### PR DESCRIPTION
Closes #27

I decided not to use `attr.asdict` or `dataclasses.asdict` because they only handle nested objects of their own kind:
```python
In [1]: import dataclasses
   ...: import attr 
   ...:  
   ...: @dataclasses.dataclass 
   ...: class Price: 
   ...:     value: int 
   ...:     currency: str 
   ...:  
   ...: @attr.s(auto_attribs=True) 
   ...: class Product: 
   ...:     name: str 
   ...:     price: Price  
   ...:

In [2]: attr.asdict(Product("Stuff", Price(50, "UYU")))
Out[2]: {'name': 'Stuff', 'price': Price(value=50, currency='UYU')}

In [3]: import dataclasses 
   ...: import attr 
   ...:  
   ...: @attr.s(auto_attribs=True) 
   ...: class Price: 
   ...:     value: int 
   ...:     currency: str 
   ...:  
   ...: @dataclasses.dataclass 
   ...: class Product: 
   ...:     name: str 
   ...:     price: Price  
   ...:

In [4]: dataclasses.asdict(Product("Stuff", Price(50, "UYU")))
Out[4]: {'name': 'Stuff', 'price': Price(value=50, currency='UYU')}
```