### PR TITLE
Avoid upstream exceptions in ItemAdapter.__repr__

### DIFF
--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -27,7 +27,8 @@ class ItemAdapter(MutableMapping):
             self._fields_dict = attr.fields_dict(self.item.__class__)
 
     def __repr__(self) -> str:
-        return "ItemAdapter for type %s: %r" % (self.item.__class__.__name__, self.item)
+        values = ", ".join(["%s=%r" % (key, value) for key, value in self.items()])
+        return "<ItemAdapter for %s(%s)>" % (self.item.__class__.__name__, values)
 
     def __getitem__(self, field_name: str) -> Any:
         if is_dataclass_instance(self.item) or is_attrs_instance(self.item):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -16,17 +16,22 @@ from tests import (
 
 class ItemAdapterReprTestCase(unittest.TestCase):
     def test_repr_dict(self):
-        item = dict(name="asdf")
+        item = dict(name="asdf", value=1234)
         adapter = ItemAdapter(item)
-        self.assertEqual(repr(adapter), "ItemAdapter for type dict: {'name': 'asdf'}")
+        # dicts are not guarantied to be sorted in py35
+        self.assertTrue(
+            repr(adapter) == "<ItemAdapter for dict(name='asdf', value=1234)>"
+            or repr(adapter) == "<ItemAdapter for dict(value=1234, name='asdf')>",
+        )
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
     def test_repr_scrapy_item(self):
         item = ScrapySubclassedItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
-        self.assertEqual(
-            repr(adapter),
-            "ItemAdapter for type ScrapySubclassedItem: {'name': 'asdf', 'value': 1234}",
+        # Scrapy fields are stored in a dict, which is not guarantied to be sorted in py35
+        self.assertTrue(
+            repr(adapter) == "<ItemAdapter for ScrapySubclassedItem(name='asdf', value=1234)>"
+            or repr(adapter) == "<ItemAdapter for ScrapySubclassedItem(value=1234, name='asdf')>",
         )
 
     @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
@@ -34,15 +39,14 @@ class ItemAdapterReprTestCase(unittest.TestCase):
         item = DataClassItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
         self.assertEqual(
-            repr(adapter),
-            "ItemAdapter for type DataClassItem: DataClassItem(name='asdf', value=1234)",
+            repr(adapter), "<ItemAdapter for DataClassItem(name='asdf', value=1234)>",
         )
 
     def test_repr_attrs(self):
         item = AttrsItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
         self.assertEqual(
-            repr(adapter), "ItemAdapter for type AttrsItem: AttrsItem(name='asdf', value=1234)",
+            repr(adapter), "<ItemAdapter for AttrsItem(name='asdf', value=1234)>",
         )
 
 


### PR DESCRIPTION
Related to #30, https://github.com/scrapy/itemloaders/issues/14

Replace the `repr` call, display the currently set fields.

Keep in mind that this only prevents the upstream `AttributeError` in `ItemAdapter.__repr__`: displaying the original wrapped item will still fail if an attribute is missing:

```python
>>> from dataclasses import dataclass
>>> from itemadapter import ItemAdapter
>>> 
>>> @dataclass(init=False)
... class Product:
...     name: str
...     price: float
... 
>>> p = Product()
>>> a = ItemAdapter(p)
>>> a["name"] = "foo"
>>> a  # this works
<ItemAdapter for Product(name='foo')>
>>> p  # but this still breaks
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/dataclasses.py", line 357, in wrapper
    result = user_function(self)
  File "<string>", line 2, in __repr__
AttributeError: 'Product' object has no attribute 'price'
```

/cc @ejulio