### PR TITLE
Also run tests without extra dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
 
 
   tests-no-extra-deps:
-    name: "Test: python3.6, Ubuntu, no deps"
+    name: "Test: py${{ matrix.python-version }}, Ubuntu, no extra deps"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,12 +58,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Build
 
-on:
-- pull_request
-- push
+on: [push]
 
 jobs:
   checks:
@@ -58,6 +56,9 @@ jobs:
   tests-no-extra-deps:
     name: "Test: python3.6, Ubuntu, no deps"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -65,7 +66,7 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: [3.5, 3.6, 3.8]
+        python-version: ${{ matrix.python-version }}
 
     - name: Install tox
       run: pip install tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      run: tox -e py
+      run: tox -e py${{ matrix.python-version }}
 
     - name: Upload coverage report
       run: bash <(curl -s https://codecov.io/bash) -cF tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   checks:
-    name: Flake8, typing, black
+    name: Lint, typing, coverage
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push]
+on:
+- pull_request
+- push
 
 jobs:
   checks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push]
+on:
+- push
+- pull_request
 
 jobs:
   checks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,13 +47,13 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      run: tox -e py${{ matrix.python-version }}
+      run: tox -e py
 
     - name: Upload coverage report
       run: bash <(curl -s https://codecov.io/bash) -cF tests
 
 
-  tests-no-deps:
+  tests-no-extra-deps:
     name: "Test: python3.6, Ubuntu, no deps"
     runs-on: ubuntu-latest
 
@@ -63,13 +63,13 @@ jobs:
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: [3.5, 3.6, 3.8]
 
     - name: Install tox
       run: pip install tox
 
     - name: Run tests
-      run: tox -e no-deps
+      run: tox -e no-extra-deps
 
     - name: Upload coverage report
       run: bash <(curl -s https://codecov.io/bash) -cF tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   checks:
-    name: Lint, typing, coverage
+    name: Flake8, typing, black
     runs-on: ubuntu-latest
 
     steps:
@@ -27,12 +27,6 @@ jobs:
     - name: Black
       run: tox -e black
 
-    - name: Generate coverage report
-      run: tox -e py
-
-    - name: Upload coverage report
-      run: bash <(curl -s https://codecov.io/bash)
-
 
   tests-ubuntu:
     name: "Test: py${{ matrix.python-version }}, Ubuntu"
@@ -54,6 +48,32 @@ jobs:
 
     - name: Run tests
       run: tox -e py
+
+    - name: Upload coverage report
+      run: bash <(curl -s https://codecov.io/bash) -cF tests
+
+
+  tests-no-deps:
+    name: "Test: python3.6, Ubuntu, no deps"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+
+    - name: Install tox
+      run: pip install tox
+
+    - name: Run tests
+      run: tox -e no-deps
+
+    - name: Upload coverage report
+      run: bash <(curl -s https://codecov.io/bash) -cF tests
+
 
   tests-other-os:
     name: "Test: py3.8, ${{ matrix.os }}"

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -170,7 +170,14 @@ class ItemAdapter(MutableMapping):
     to extract and set data without having to take the object's type into account.
     """
 
-    ADAPTER_CLASSES = deque([ScrapyItemAdapter, DictAdapter, DataclassAdapter, AttrsAdapter])
+    ADAPTER_CLASSES = deque(
+        [
+            ScrapyItemAdapter,
+            DictAdapter,
+            DataclassAdapter,
+            AttrsAdapter,
+        ]
+    )
 
     def __init__(self, item: Any) -> None:
         self.adapter_class = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,13 +1,20 @@
+import os
+import sys
+from unittest import skipIf, TestCase as _TestCase
+
+
 try:
     import attr
 except ImportError:
     AttrsItem = None
 else:
-
-    @attr.s
-    class AttrsItem:
-        name = attr.ib(default=None, metadata={"serializer": str})
-        value = attr.ib(default=None, metadata={"serializer": int})
+    if os.environ.get('ITEMADAPTER_NO_EXTRA_DEPS'):
+        AttrsItem = None
+    else:
+        @attr.s
+        class AttrsItem:
+            name = attr.ib(default=None, metadata={"serializer": str})
+            value = attr.ib(default=None, metadata={"serializer": int})
 
 
 try:
@@ -15,13 +22,19 @@ try:
 except ImportError:
     DataClassItem = None
 else:
-    DataClassItem = make_dataclass(
-        "DataClassItem",
-        [
-            ("name", str, field(default_factory=lambda: None, metadata={"serializer": str})),
-            ("value", int, field(default_factory=lambda: None, metadata={"serializer": int})),
-        ],
-    )
+    if (
+        os.environ.get('ITEMADAPTER_NO_EXTRA_DEPS')
+        and (3, 6) <= sys.version_info < (3, 7)
+    ):
+        DataClassItem = None
+    else:
+        DataClassItem = make_dataclass(
+            "DataClassItem",
+            [
+                ("name", str, field(default_factory=lambda: None, metadata={"serializer": str})),
+                ("value", int, field(default_factory=lambda: None, metadata={"serializer": int})),
+            ],
+        )
 
 
 try:
@@ -30,7 +43,85 @@ except ImportError:
     ScrapyItem = None
     ScrapySubclassedItem = None
 else:
+    if os.environ.get('ITEMADAPTER_NO_EXTRA_DEPS'):
+        ScrapyItem = None
+        ScrapySubclassedItem = None
+    else:
+        class ScrapySubclassedItem(ScrapyItem):
+            name = Field(serializer=str)
+            value = Field(serializer=int)
 
-    class ScrapySubclassedItem(ScrapyItem):
-        name = Field(serializer=str)
-        value = Field(serializer=int)
+
+class ImportRaiser:
+
+    def __init__(self, *packages):
+        self.packages = set(packages)
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.packages:
+            raise ImportError
+
+
+class TestCase(_TestCase):
+    """Custom TestCase subclass which handles disabling installed extra
+    packages during tests when ITEMADAPTER_NO_EXTRA_DEPS is set, as well as
+    disabling test cases that require one or more unavailable extra
+    dependencies.
+
+    This is needed to disable packages that cannot be uninstalled because
+    pytest depends on them.
+    """
+
+    _extra_modules = ('attr', 'scrapy')
+
+    def setUp(self):
+        super().setUp()
+
+        required_extra_modules = getattr(self, 'required_extra_modules', None)
+        if required_extra_modules:
+            requirement_map = {
+                'attr': AttrsItem,
+                'dataclasses': DataClassItem,
+                'scrapy': ScrapyItem,
+            }
+            unknown_extra_modules = [module
+                                     for module in required_extra_modules
+                                     if module not in requirement_map]
+            if unknown_extra_modules:
+                raise NotImplementedError(
+                    'Unknown extra modules: {}'.format(unknown_extra_modules)
+                )
+            unavaliable_extra_modules = [module
+                                         for module in required_extra_modules
+                                         if not requirement_map[module]]
+            if unavaliable_extra_modules:
+                self.skipTest(
+                    'cannot import; {}'.format(
+                        ', '.join(unavaliable_extra_modules)
+                    )
+                )
+
+
+        self._removed_modules = {}
+        if os.environ.get('ITEMADAPTER_NO_EXTRA_DEPS'):
+            if (3, 6) <= sys.version_info < (3, 7):
+                self._extra_modules = self._extra_modules + ('dataclasses',)
+            sys.meta_path.insert(0, ImportRaiser(*self._extra_modules))
+            for package in self._extra_modules:
+                if package in sys.modules:
+                    self._removed_modules[package] = sys.modules[package]
+                    del sys.modules[package]
+
+    def tearDown(self):
+        super().tearDown()
+
+        if os.environ.get('ITEMADAPTER_NO_EXTRA_DEPS'):
+            del sys.meta_path[0]
+            for package in self._extra_modules:
+                if package in self._removed_modules:
+                    sys.modules[package] = self._removed_modules[package]
+
+
+requires_attr = skipIf(not AttrsItem, "cannot import attr")
+requires_dataclasses = skipIf(not DataClassItem, "cannot import dataclasses")
+requires_scrapy = skipIf(not ScrapyItem, "cannot import scrapy")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,18 +2,14 @@ import os
 import sys
 from unittest import skipIf, TestCase as _TestCase
 
-from itemadapter.adapter import ItemAdapter
-
 
 try:
     import attr
 except ImportError:
     AttrsItem = None
-    AttrsItemNested = None
 else:
     if os.environ.get("ITEMADAPTER_NO_EXTRA_DEPS"):
         AttrsItem = None
-        AttrsItemNested = None
     else:
 
         @attr.s
@@ -21,45 +17,20 @@ else:
             name = attr.ib(default=None, metadata={"serializer": str})
             value = attr.ib(default=None, metadata={"serializer": int})
 
-        @attr.s
-        class AttrsItemNested:
-            nested = attr.ib(type=AttrsItem)
-            adapter = attr.ib(type=ItemAdapter)
-            dict_ = attr.ib(type=dict)
-            list_ = attr.ib(type=list)
-            set_ = attr.ib(type=set)
-            tuple_ = attr.ib(type=tuple)
-            int_ = attr.ib(type=int)
-
 
 try:
-    from dataclasses import make_dataclass, field
+    from dataclasses import field, make_dataclass
 except ImportError:
     DataClassItem = None
-    DataClassItemNested = None
 else:
     if os.environ.get("ITEMADAPTER_NO_EXTRA_DEPS") and (3, 6) <= sys.version_info < (3, 7):
         DataClassItem = None
-        DataClassItemNested = None
     else:
         DataClassItem = make_dataclass(
             "DataClassItem",
             [
                 ("name", str, field(default_factory=lambda: None, metadata={"serializer": str})),
                 ("value", int, field(default_factory=lambda: None, metadata={"serializer": int})),
-            ],
-        )
-
-        DataClassItemNested = make_dataclass(
-            "DataClassItem",
-            [
-                ("nested", DataClassItem),
-                ("adapter", ItemAdapter),
-                ("dict_", dict),
-                ("list_", list),
-                ("set_", set),
-                ("tuple_", tuple),
-                ("int_", int),
             ],
         )
 

--- a/tests/attr_utils.py
+++ b/tests/attr_utils.py
@@ -1,0 +1,19 @@
+"""Code for attr.s tests that must only be imported from within tests because
+it imports from itemadapter."""
+
+import attr
+
+from itemadapter import ItemAdapter
+
+from tests import AttrsItem
+
+
+@attr.s
+class AttrsItemNested:
+    nested = attr.ib(type=AttrsItem)
+    adapter = attr.ib(type=ItemAdapter)
+    dict_ = attr.ib(type=dict)
+    list_ = attr.ib(type=list)
+    set_ = attr.ib(type=set)
+    tuple_ = attr.ib(type=tuple)
+    int_ = attr.ib(type=int)

--- a/tests/dataclasses_utils.py
+++ b/tests/dataclasses_utils.py
@@ -1,0 +1,22 @@
+"""Code for dataclass tests that must only be imported from within tests
+because it imports from itemadapter."""
+
+from dataclasses import make_dataclass
+
+from itemadapter import ItemAdapter
+
+from tests import DataClassItem
+
+
+DataClassItemNested = make_dataclass(
+    "DataClassItem",
+    [
+        ("nested", DataClassItem),
+        ("adapter", ItemAdapter),
+        ("dict_", dict),
+        ("list_", list),
+        ("set_", set),
+        ("tuple_", tuple),
+        ("int_", int),
+    ],
+)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,0 @@
-attrs
-dataclasses; python_version == "3.6"
-pytest-cov>=2.8
-pytest>=5.4
-scrapy>=2.0

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -2,18 +2,28 @@ import unittest
 from types import MappingProxyType
 from typing import KeysView
 
+import pytest
+
 from itemadapter.adapter import ItemAdapter
 
-from tests import AttrsItem, DataClassItem, ScrapySubclassedItem
+from tests import (
+    AttrsItem,
+    DataClassItem,
+    requires_attr,
+    requires_dataclasses,
+    requires_scrapy,
+    ScrapySubclassedItem,
+    TestCase,
+)
 
 
-class ItemAdapterReprTestCase(unittest.TestCase):
+class ItemAdapterReprTestCase(TestCase):
     def test_repr_dict(self):
         item = dict(name="asdf")
         adapter = ItemAdapter(item)
         self.assertEqual(repr(adapter), "ItemAdapter for type dict: {'name': 'asdf'}")
 
-    @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
+    @requires_scrapy
     def test_repr_scrapy_item(self):
         item = ScrapySubclassedItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
@@ -22,7 +32,7 @@ class ItemAdapterReprTestCase(unittest.TestCase):
             "ItemAdapter for type ScrapySubclassedItem: {'name': 'asdf', 'value': 1234}",
         )
 
-    @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
+    @requires_dataclasses
     def test_repr_dataclass(self):
         item = DataClassItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
@@ -31,6 +41,7 @@ class ItemAdapterReprTestCase(unittest.TestCase):
             "ItemAdapter for type DataClassItem: DataClassItem(name='asdf', value=1234)",
         )
 
+    @requires_attr
     def test_repr_attrs(self):
         item = AttrsItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
@@ -39,7 +50,7 @@ class ItemAdapterReprTestCase(unittest.TestCase):
         )
 
 
-class ItemAdapterInitError(unittest.TestCase):
+class ItemAdapterInitError(TestCase):
     def test_non_item(self):
         with self.assertRaises(TypeError):
             ItemAdapter(ScrapySubclassedItem)
@@ -54,6 +65,7 @@ class BaseTestMixin:
     item_class = None
 
     def setUp(self):
+        super().setUp()
         if self.item_class is None:
             raise unittest.SkipTest()
 
@@ -135,7 +147,7 @@ class NonDictTestMixin(BaseTestMixin):
             del adapter["undefined_field"]
 
 
-class DictTestCase(unittest.TestCase, BaseTestMixin):
+class DictTestCase(TestCase, BaseTestMixin):
 
     item_class = dict
 
@@ -158,7 +170,7 @@ class DictTestCase(unittest.TestCase, BaseTestMixin):
         self.assertEqual(sorted(field_names), ["name", "value"])
 
 
-class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
+class ScrapySubclassedItemTestCase(NonDictTestMixin, TestCase):
 
     item_class = ScrapySubclassedItem
 
@@ -169,11 +181,11 @@ class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
             adapter["name"]
 
 
-class DataClassItemTestCase(NonDictTestMixin, unittest.TestCase):
+class DataClassItemTestCase(NonDictTestMixin, TestCase):
 
     item_class = DataClassItem
 
 
-class AttrsItemTestCase(NonDictTestMixin, unittest.TestCase):
+class AttrsItemTestCase(NonDictTestMixin, TestCase):
 
     item_class = AttrsItem

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,6 @@
 import unittest
 from unittest import mock
 
-from itemadapter.utils import is_item, is_attrs_instance, is_dataclass_instance, is_scrapy_item
-
 from tests import (
     AttrsItem,
     DataClassItem,
@@ -17,6 +15,8 @@ from tests import (
 
 class ItemLikeTestCase(TestCase):
     def test_false(self):
+        from itemadapter.utils import is_item
+
         self.assertFalse(is_item(int))
         self.assertFalse(is_item(sum))
         self.assertFalse(is_item(1234))
@@ -33,24 +33,34 @@ class ItemLikeTestCase(TestCase):
         self.assertFalse(is_item(AttrsItem))
 
     def test_true_dict(self):
+        from itemadapter.utils import is_item
+
         self.assertTrue(is_item({"a": "dict"}))
 
     @requires_scrapy
     def test_true_scrapy(self):
+        from itemadapter.utils import is_item
+
         self.assertTrue(is_item(ScrapyItem()))
         self.assertTrue(is_item(ScrapySubclassedItem(name="asdf", value=1234)))
 
     @requires_dataclasses
     def test_true_dataclass(self):
+        from itemadapter.utils import is_item
+
         self.assertTrue(is_item(DataClassItem(name="asdf", value=1234)))
 
     @requires_attr
     def test_true_attrs(self):
+        from itemadapter.utils import is_item
+
         self.assertTrue(is_item(AttrsItem(name="asdf", value=1234)))
 
 
 class AttrsTestCase(TestCase):
     def test_false(self):
+        from itemadapter.utils import is_attrs_instance
+
         self.assertFalse(is_attrs_instance(int))
         self.assertFalse(is_attrs_instance(sum))
         self.assertFalse(is_attrs_instance(1234))
@@ -65,12 +75,16 @@ class AttrsTestCase(TestCase):
 
     @requires_attr
     def test_true(self):
+        from itemadapter.utils import is_attrs_instance
+
         self.assertTrue(is_attrs_instance(AttrsItem()))
         self.assertTrue(is_attrs_instance(AttrsItem(name="asdf", value=1234)))
 
 
 class DataclassTestCase(TestCase):
     def test_false(self):
+        from itemadapter.utils import is_dataclass_instance
+
         self.assertFalse(is_dataclass_instance(int))
         self.assertFalse(is_dataclass_instance(sum))
         self.assertFalse(is_dataclass_instance(1234))
@@ -85,12 +99,16 @@ class DataclassTestCase(TestCase):
 
     @requires_dataclasses
     def test_true(self):
+        from itemadapter.utils import is_dataclass_instance
+
         self.assertTrue(is_dataclass_instance(DataClassItem()))
         self.assertTrue(is_dataclass_instance(DataClassItem(name="asdf", value=1234)))
 
 
 class ScrapyItemTestCase(TestCase):
     def test_false(self):
+        from itemadapter.utils import is_scrapy_item
+
         self.assertFalse(is_scrapy_item(int))
         self.assertFalse(is_scrapy_item(sum))
         self.assertFalse(is_scrapy_item(1234))
@@ -105,6 +123,8 @@ class ScrapyItemTestCase(TestCase):
 
     @requires_scrapy
     def test_true(self):
+        from itemadapter.utils import is_scrapy_item
+
         self.assertTrue(is_scrapy_item(ScrapyItem()))
         self.assertTrue(is_scrapy_item(ScrapySubclassedItem()))
         self.assertTrue(is_scrapy_item(ScrapySubclassedItem(name="asdf", value=1234)))
@@ -128,6 +148,8 @@ class ScrapyDeprecatedBaseItemTestCase(TestCase):
         not hasattr(scrapy.item, "_BaseItem"), "scrapy.item._BaseItem not available",
     )
     def test_deprecated_underscore_baseitem(self):
+        from itemadapter.utils import is_scrapy_item
+
         class SubClassed_BaseItem(scrapy.item._BaseItem):
             pass
 
@@ -138,6 +160,8 @@ class ScrapyDeprecatedBaseItemTestCase(TestCase):
         not hasattr(scrapy.item, "BaseItem"), "scrapy.item.BaseItem not available",
     )
     def test_deprecated_baseitem(self):
+        from itemadapter.utils import is_scrapy_item
+
         class SubClassedBaseItem(scrapy.item.BaseItem):
             pass
 
@@ -145,6 +169,8 @@ class ScrapyDeprecatedBaseItemTestCase(TestCase):
         self.assertTrue(is_scrapy_item(SubClassedBaseItem()))
 
     def test_removed_baseitem(self):
+        from itemadapter.utils import is_scrapy_item
+
         class MockItemModule:
             Item = ScrapyItem
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,6 @@ from itemadapter.utils import is_item, is_attrs_instance, is_dataclass_instance,
 from tests import AttrsItem, DataClassItem, ScrapyItem, ScrapySubclassedItem
 
 
-def mocked_import(name, *args, **kwargs):
-    raise ImportError(name)
-
-
 class ItemLikeTestCase(unittest.TestCase):
     def test_false(self):
         self.assertFalse(is_item(int))
@@ -50,8 +46,6 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(is_attrs_instance(sum))
         self.assertFalse(is_attrs_instance(1234))
         self.assertFalse(is_attrs_instance(object()))
-        self.assertFalse(is_attrs_instance(ScrapyItem()))
-        self.assertFalse(is_attrs_instance(ScrapySubclassedItem()))
         self.assertFalse(is_attrs_instance("a string"))
         self.assertFalse(is_attrs_instance(b"some bytes"))
         self.assertFalse(is_attrs_instance({"a": "dict"}))
@@ -59,11 +53,6 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(is_attrs_instance(("a", "tuple")))
         self.assertFalse(is_attrs_instance({"a", "set"}))
         self.assertFalse(is_attrs_instance(AttrsItem))
-
-    @unittest.skipIf(not AttrsItem, "attrs module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
-    def test_module_not_available(self):
-        self.assertFalse(is_attrs_instance(AttrsItem(name="asdf", value=1234)))
 
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
     def test_true(self):
@@ -77,9 +66,6 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(is_dataclass_instance(sum))
         self.assertFalse(is_dataclass_instance(1234))
         self.assertFalse(is_dataclass_instance(object()))
-        self.assertFalse(is_dataclass_instance(ScrapyItem()))
-        self.assertFalse(is_dataclass_instance(AttrsItem()))
-        self.assertFalse(is_dataclass_instance(ScrapySubclassedItem()))
         self.assertFalse(is_dataclass_instance("a string"))
         self.assertFalse(is_dataclass_instance(b"some bytes"))
         self.assertFalse(is_dataclass_instance({"a": "dict"}))
@@ -87,11 +73,6 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(is_dataclass_instance(("a", "tuple")))
         self.assertFalse(is_dataclass_instance({"a", "set"}))
         self.assertFalse(is_dataclass_instance(DataClassItem))
-
-    @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
-    def test_module_not_available(self):
-        self.assertFalse(is_dataclass_instance(DataClassItem(name="asdf", value=1234)))
 
     @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
     def test_true(self):
@@ -105,7 +86,6 @@ class ScrapyItemTestCase(unittest.TestCase):
         self.assertFalse(is_scrapy_item(sum))
         self.assertFalse(is_scrapy_item(1234))
         self.assertFalse(is_scrapy_item(object()))
-        self.assertFalse(is_scrapy_item(AttrsItem()))
         self.assertFalse(is_scrapy_item("a string"))
         self.assertFalse(is_scrapy_item(b"some bytes"))
         self.assertFalse(is_scrapy_item({"a": "dict"}))
@@ -113,11 +93,6 @@ class ScrapyItemTestCase(unittest.TestCase):
         self.assertFalse(is_scrapy_item(("a", "tuple")))
         self.assertFalse(is_scrapy_item({"a", "set"}))
         self.assertFalse(is_scrapy_item(ScrapySubclassedItem))
-
-    @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
-    def test_module_not_available(self):
-        self.assertFalse(is_scrapy_item(ScrapySubclassedItem(name="asdf", value=1234)))
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
     def test_true(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,63 +1,39 @@
 [tox]
-envlist = flake8,typing,black,py3.5,py3.6,py3.7,py3.8,no-deps
+envlist = flake8,typing,black,py,no-extra-deps
 
-[testenv]
+[base]
 deps =
     pytest>=5.4
     pytest-cov>=2.8
+
+[testenv]
+deps =
+    {[base]deps}
+    attrs
+    dataclasses; python_version >= '3.6' and python_version < '3.7'
+    scrapy>=2.0
 commands =
     pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --cov-append {posargs: itemadapter tests}
 
-[testenv:py3.5]
-basepython = python3.5
+[testenv:no-extra-deps]
 deps =
     {[testenv]deps}
-    attrs
-    scrapy>=2.0
-
-[testenv:py3.6]
-basepython = python3.6
-deps =
-    {[testenv]deps}
-    attrs
-    dataclasses
-    scrapy>=2.0
-
-[testenv:py3.7]
-basepython = python3.7
-deps =
-    {[testenv]deps}
-    attrs
-    scrapy>=2.0
-
-[testenv:py3.8]
-basepython = python3.8
-deps =
-    {[testenv]deps}
-    attrs
-    scrapy>=2.0
-
-[testenv:no-deps]
-deps =
-    {[testenv]deps}
-basepython = python3.6
+setenv =
+    ITEMADAPTER_NO_EXTRA_DEPS=True
 
 [testenv:flake8]
-basepython = python3.8
 deps =
     flake8>=3.7.9
 commands =
     flake8 --exclude=.git,.tox,venv* itemadapter tests
 
 [testenv:typing]
-basepython = python3.8
 deps =
     mypy==0.770
 commands =
     mypy --ignore-missing-imports --follow-imports=skip itemadapter
 
 [testenv:black]
-basepython = python3.8
 deps =
     black>=19.10b0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,typing,black,py35,py36,py37,py38,no-deps
+envlist = flake8,typing,black,py3.5,py3.6,py3.7,py3.8,no-deps
 
 [testenv]
 deps =
@@ -8,14 +8,14 @@ deps =
 commands =
     pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --cov-append {posargs: itemadapter tests}
 
-[testenv:py35]
+[testenv:py3.5]
 basepython = python3.5
 deps =
     {[testenv]deps}
     attrs
     scrapy>=2.0
 
-[testenv:py36]
+[testenv:py3.6]
 basepython = python3.6
 deps =
     {[testenv]deps}
@@ -23,14 +23,14 @@ deps =
     dataclasses
     scrapy>=2.0
 
-[testenv:py37]
+[testenv:py3.7]
 basepython = python3.7
 deps =
     {[testenv]deps}
     attrs
     scrapy>=2.0
 
-[testenv:py38]
+[testenv:py3.8]
 basepython = python3.8
 deps =
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,46 @@
 [tox]
-envlist = py35,py36,py37,py38,flake8,typing,black
+envlist = py35,py36,py37,py38,no-deps,flake8,typing,black
 
 [testenv]
 deps =
-    -rtests/requirements.txt
+    pytest>=5.4
+    pytest-cov>=2.8
 commands =
-    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: itemadapter tests}
+    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --cov-append {posargs: itemadapter tests}
 
 [testenv:py35]
 basepython = python3.5
+deps =
+    {[testenv]deps}
+    attrs
+    scrapy>=2.0
 
 [testenv:py36]
 basepython = python3.6
+deps =
+    {[testenv]deps}
+    attrs
+    dataclasses
+    scrapy>=2.0
 
 [testenv:py37]
 basepython = python3.7
+deps =
+    {[testenv]deps}
+    attrs
+    scrapy>=2.0
 
 [testenv:py38]
 basepython = python3.8
+deps =
+    {[testenv]deps}
+    attrs
+    scrapy>=2.0
+
+[testenv:no-deps]
+deps =
+    {[testenv]deps}
+basepython = python3.6
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
Continuation of #22 which also prevents extra packages from being imported during test execution even if they are installed.

Fixes #10, closes #22