### PR TITLE
Test code from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ The following is a simple example using a `dataclass` object.
 Consider the following type definition:
 
 ```python
-from dataclasses import dataclass
-from itemadapter import ItemAdapter, is_item
-
-@dataclass
-class InventoryItem:
-    name: str
-    price: float
-    stock: int
+>>> from dataclasses import dataclass
+>>> from itemadapter import ItemAdapter, is_item
+>>> @dataclass
+... class InventoryItem:
+...     name: str
+...     price: float
+...     stock: int
+>>>
 ```
 
 The `ItemAdapter` object can be treated much like a dictionary:
@@ -70,6 +70,7 @@ True
 'foo'
 >>> adapter.get("price")
 20.5
+>>>
 ```
 
 The wrapped object is modified in-place:
@@ -80,6 +81,7 @@ The wrapped object is modified in-place:
 InventoryItem(name='bar', price=12.7, stock=9)
 >>> adapter.item is obj
 True
+>>>
 ```
 
 ### Converting to dict
@@ -88,25 +90,25 @@ The `ItemAdapter` class provides the `asdict` method, which converts
 nested items recursively. Consider the following example:
 
 ```python
-from dataclasses import dataclass
-from itemadapter import ItemAdapter
-
-@dataclass
-class Price:
-    value: int
-    currency: str
-
-@dataclass
-class Product:
-    name: str
-    price: Price
+>>> from dataclasses import dataclass
+>>> from itemadapter import ItemAdapter
+>>> @dataclass
+... class Price:
+...     value: int
+...     currency: str
+>>> @dataclass
+... class Product:
+...     name: str
+...     price: Price
+>>>
 ```
 
 ```python
 >>> item = Product("Stuff", Price(42, "UYU"))
 >>> adapter = ItemAdapter(item)
 >>> adapter.asdict()
-{'name': 'Stuff', 'price': {'currency': 'UYU', 'value': 42}}
+{'name': 'Stuff', 'price': {'value': 42, 'currency': 'UYU'}}
+>>>
 ```
 
 Note that just passing an adapter object to the `dict` built-in also works,
@@ -115,6 +117,7 @@ but it doesn't traverse the object recursively converting nested items:
 ```python
 >>> dict(adapter)
 {'name': 'Stuff', 'price': Price(value=42, currency='UYU')}
+>>>
 ```
 
 
@@ -185,6 +188,7 @@ underlying type.
 mappingproxy({'serializer': <class 'str'>})
 >>> adapter.get_field_meta("value")
 mappingproxy({'serializer': <class 'int'>, 'limit': 100})
+>>>
 ```
 
 #### `dataclass` objects
@@ -201,6 +205,7 @@ mappingproxy({'serializer': <class 'int'>, 'limit': 100})
 mappingproxy({'serializer': <class 'str'>})
 >>> adapter.get_field_meta("value")
 mappingproxy({'serializer': <class 'int'>, 'limit': 100})
+>>>
 ```
 
 #### `attrs` objects
@@ -216,7 +221,8 @@ mappingproxy({'serializer': <class 'int'>, 'limit': 100})
 >>> adapter.get_field_meta("name")
 mappingproxy({'serializer': <class 'str'>})
 >>> adapter.get_field_meta("value")
-mappingproxy({'serializer': <class 'int'>})
+mappingproxy({'serializer': <class 'int'>, 'limit': 100})
+>>>
 ```
 
 
@@ -241,6 +247,7 @@ True
 >>> adapter["price"] = 5
 >>> item
 {'name': 'bar', 'price': 5}
+>>>
 ```
 
 ### `dict`
@@ -257,6 +264,7 @@ True
 >>> adapter["price"] = 5
 >>> item
 {'name': 'bar', 'price': 5}
+>>>
 ```
 
 ### `dataclass` objects
@@ -279,6 +287,7 @@ True
 >>> adapter["price"] = 5
 >>> item
 InventoryItem(name='bar', price=5)
+>>>
 ```
 
 ### `attrs` objects
@@ -301,4 +310,5 @@ True
 >>> adapter["price"] = 5
 >>> item
 InventoryItem(name='bar', price=5)
+>>>
 ```

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -39,14 +39,16 @@ class ItemAdapterReprTestCase(unittest.TestCase):
         item = DataClassItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
         self.assertEqual(
-            repr(adapter), "<ItemAdapter for DataClassItem(name='asdf', value=1234)>",
+            repr(adapter),
+            "<ItemAdapter for DataClassItem(name='asdf', value=1234)>",
         )
 
     def test_repr_attrs(self):
         item = AttrsItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
         self.assertEqual(
-            repr(adapter), "<ItemAdapter for AttrsItem(name='asdf', value=1234)>",
+            repr(adapter),
+            "<ItemAdapter for AttrsItem(name='asdf', value=1234)>",
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = flake8,typing,black,py35,py36,py37,py38
 deps =
     -rtests/requirements.txt
 commands =
-    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: itemadapter tests}
+    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --doctest-glob=README.md {posargs: itemadapter README.md tests}
 
 [testenv:py35]
 basepython = python3.5


### PR DESCRIPTION
In order to avoid using Sybil, I’ve had to:

- Turn non-doctest (i.e. without `>>>`) code blocks into doctest
- I had to add `>>>` at the end of every block of code, because otherwise ` ``` ` would be picked up as expected output.

The changes fix 2 issues, a sorting issue and a missing parameter in output.