### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently supported types are:
 
 ## Requirements
 
-* Python 3.5+
+* Python 3.6+
 * [`scrapy`](https://scrapy.org/): optional, needed to interact with `scrapy` items
 * `dataclasses` ([stdlib](https://docs.python.org/3/library/dataclasses.html) in Python 3.7+,
   or its [backport](https://pypi.org/project/dataclasses/) in Python 3.6): optional, needed

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -5,8 +5,7 @@ def is_dataclass_instance(obj: Any) -> bool:
     """
     Return True if the given object is a dataclass object, False otherwise.
 
-    This function always returns False in py35. In py36, it returns False
-    if the "dataclasses" backport is not available.
+    In py36, this function returns False if the "dataclasses" backport is not available.
 
     Taken from https://docs.python.org/3/library/dataclasses.html#dataclasses.is_dataclass.
     """

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ setuptools.setup(
     author_email="eugenio.lacuesta@gmail.com",
     url="https://github.com/scrapy/itemadapter",
     packages=["itemadapter"],
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -18,20 +18,14 @@ class ItemAdapterReprTestCase(unittest.TestCase):
     def test_repr_dict(self):
         item = dict(name="asdf", value=1234)
         adapter = ItemAdapter(item)
-        # dicts are not guarantied to be sorted in py35
-        self.assertTrue(
-            repr(adapter) == "<ItemAdapter for dict(name='asdf', value=1234)>"
-            or repr(adapter) == "<ItemAdapter for dict(value=1234, name='asdf')>",
-        )
+        self.assertEqual(repr(adapter), "<ItemAdapter for dict(name='asdf', value=1234)>")
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
     def test_repr_scrapy_item(self):
         item = ScrapySubclassedItem(name="asdf", value=1234)
         adapter = ItemAdapter(item)
-        # Scrapy fields are stored in a dict, which is not guarantied to be sorted in py35
-        self.assertTrue(
-            repr(adapter) == "<ItemAdapter for ScrapySubclassedItem(name='asdf', value=1234)>"
-            or repr(adapter) == "<ItemAdapter for ScrapySubclassedItem(value=1234, name='asdf')>",
+        self.assertEqual(
+            repr(adapter), "<ItemAdapter for ScrapySubclassedItem(name='asdf', value=1234)>"
         )
 
     @unittest.skipIf(not DataClassItem, "dataclasses module is not available")

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = flake8,typing,black,py35,py36,py37,py38
+envlist = flake8,typing,black,py36,py37,py38
 
 [testenv]
 deps =
     -rtests/requirements.txt
 commands =
     pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: itemadapter tests}
-
-[testenv:py35]
-basepython = python3.5
 
 [testenv:py36]
 basepython = python3.6


### PR DESCRIPTION
Support for Python 3.5 was recently dropped from Scrapy (https://github.com/scrapy/scrapy/pull/4742, to be released).

This PR should fix the current problem with #36.