### PR TITLE
Ignore Scrapy warnings about BaseItem during tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:.*BaseItem.*:scrapy.exceptions.ScrapyDeprecationWarning


### PR DESCRIPTION
After this tests should yield no warnings.