### PR TITLE
tox: add bandit and improve

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,typing,black,py36,py37,py38
+envlist = bandit,flake8,typing,black,py36,py37,py38
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -15,21 +15,21 @@ commands =
     bandit -r {posargs:itemadapter}
 
 [testenv:flake8]
-basepython = python3.8
+basepython = python3
 deps =
     flake8>=3.7.9
 commands =
     flake8 --exclude=.git,.tox,venv* itemadapter tests
 
 [testenv:typing]
-basepython = python3.8
+basepython = python3
 deps =
     mypy==0.770
 commands =
     mypy --ignore-missing-imports --follow-imports=skip itemadapter
 
 [testenv:black]
-basepython = python3.8
+basepython = python3
 deps =
     black>=19.10b0
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -19,18 +19,18 @@ basepython = python3
 deps =
     flake8>=3.7.9
 commands =
-    flake8 --exclude=.git,.tox,venv* itemadapter tests
+    flake8 --exclude=.git,.tox,venv* {posargs:itemadapter tests}
 
 [testenv:typing]
 basepython = python3
 deps =
     mypy==0.770
 commands =
-    mypy --ignore-missing-imports --follow-imports=skip itemadapter
+    mypy --ignore-missing-imports --follow-imports=skip {posargs:itemadapter}
 
 [testenv:black]
 basepython = python3
 deps =
     black>=19.10b0
 commands =
-    black --check itemadapter tests
+    black --check {posargs:itemadapter tests}

--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,6 @@ deps =
 commands =
     pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: itemadapter tests}
 
-[testenv:py36]
-basepython = python3.6
-
-[testenv:py37]
-basepython = python3.7
-
-[testenv:py38]
-basepython = python3.8
-
 [testenv:bandit]
 basepython = python3
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = bandit,flake8,typing,black,py36,py37,py38
+envlist = bandit,flake8,typing,black,py
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,13 @@ basepython = python3.7
 [testenv:py38]
 basepython = python3.8
 
+[testenv:bandit]
+basepython = python3
+deps =
+    bandit
+commands =
+    bandit -r {posargs:itemadapter}
+
 [testenv:flake8]
 basepython = python3.8
 deps =


### PR DESCRIPTION
Added `bandit`, made it possible to run `tox` (without parameters) locally by removing the version-specific `py` items from the default parameters, and allowed overriding the folders and files to test with static analyzers using `posargs`.