### PR TITLE
Remove leading newline in docstrings

### DIFF
--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -23,8 +23,7 @@ __all__ = [
 
 
 class AdapterInterface(MutableMapping, metaclass=ABCMeta):
-    """
-    Abstract Base Class for adapters.
+    """Abstract Base Class for adapters.
 
     An adapter that handles a specific type of item should inherit from this
     class and implement the abstract methods defined here, plus the
@@ -37,21 +36,15 @@ class AdapterInterface(MutableMapping, metaclass=ABCMeta):
     @classmethod
     @abstractmethod
     def is_item(cls, item: Any) -> bool:
-        """
-        Return True if the adapter can handle the given item, False otherwise
-        """
+        """Return True if the adapter can handle the given item, False otherwise"""
         raise NotImplementedError()
 
     def get_field_meta(self, field_name: str) -> MappingProxyType:
-        """
-        Return metadata for the given field name, if available
-        """
+        """Return metadata for the given field name, if available."""
         return MappingProxyType({})
 
     def field_names(self) -> KeysView:
-        """
-        Return a dynamic view of the item's field names
-        """
+        """Return a dynamic view of the item's field names."""
         return self.keys()  # type: ignore[return-value]
 
 
@@ -165,8 +158,7 @@ class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
 
 
 class ItemAdapter(MutableMapping):
-    """
-    Wrapper class to interact with data container objects. It provides a common interface
+    """Wrapper class to interact with data container objects. It provides a common interface
     to extract and set data without having to take the object's type into account.
     """
 
@@ -215,8 +207,7 @@ class ItemAdapter(MutableMapping):
         return self.adapter.__len__()
 
     def get_field_meta(self, field_name: str) -> MappingProxyType:
-        """
-        Return a read-only mapping with metadata for the given field name. If there is no metadata
+        """Return a read-only mapping with metadata for the given field name. If there is no metadata
         for the field, or the wrapped item does not support field metadata, an empty object is
         returned.
 
@@ -231,23 +222,18 @@ class ItemAdapter(MutableMapping):
         return self.adapter.get_field_meta(field_name)
 
     def field_names(self) -> KeysView:
-        """
-        Return read-only key view with the names of all the defined fields for the item
-        """
+        """Return read-only key view with the names of all the defined fields for the item."""
         return self.adapter.field_names()
 
     def asdict(self) -> dict:
-        """
-        Return a dict object with the contents of the adapter. This works slightly different than
+        """Return a dict object with the contents of the adapter. This works slightly different than
         calling `dict(adapter)`: it's applied recursively to nested items (if there are any).
         """
         return {key: _asdict(value) for key, value in self.items()}
 
 
 def _asdict(obj: Any) -> Any:
-    """
-    Helper for ItemAdapter.asdict
-    """
+    """Helper for ItemAdapter.asdict()."""
     if isinstance(obj, dict):
         return {key: _asdict(value) for key, value in obj.items()}
     elif isinstance(obj, (list, set, tuple)):

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -32,8 +32,7 @@ def _is_attrs_class(obj: Any) -> bool:
 
 
 def is_dataclass_instance(obj: Any) -> bool:
-    """
-    Return True if the given object is a dataclass object, False otherwise.
+    """Return True if the given object is a dataclass object, False otherwise.
 
     In py36, this function returns False if the "dataclasses" backport is not available.
 
@@ -43,16 +42,12 @@ def is_dataclass_instance(obj: Any) -> bool:
 
 
 def is_attrs_instance(obj: Any) -> bool:
-    """
-    Return True if the given object is a attrs-based object, False otherwise.
-    """
+    """Return True if the given object is a attrs-based object, False otherwise."""
     return _is_attrs_class(obj) and not isinstance(obj, type)
 
 
 def is_scrapy_item(obj: Any) -> bool:
-    """
-    Return True if the given object is a Scrapy item, False otherwise.
-    """
+    """Return True if the given object is a Scrapy item, False otherwise."""
     try:
         import scrapy
     except ImportError:
@@ -68,8 +63,7 @@ def is_scrapy_item(obj: Any) -> bool:
 
 
 def is_item(obj: Any) -> bool:
-    """
-    Return True if the given object belongs to one of the supported types, False otherwise.
+    """Return True if the given object belongs to one of the supported types, False otherwise.
 
     Alias for ItemAdapter.is_item
     """
@@ -79,8 +73,7 @@ def is_item(obj: Any) -> bool:
 
 
 def get_field_meta_from_class(item_class: type, field_name: str) -> MappingProxyType:
-    """
-    Return a read-only mapping with metadata for the given field name, within the given item class.
+    """Return a read-only mapping with metadata for the given field name, within the given item class.
     If there is no metadata for the field, or the item class does not support field metadata,
     an empty object is returned.
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -196,7 +196,7 @@ class DictTestCase(unittest.TestCase, BaseTestMixin):
     item_class_nested = dict
 
     def test_get_value_keyerror_item_dict(self):
-        """Instantiate without default values"""
+        """Instantiate without default values."""
         adapter = ItemAdapter(self.item_class())
         with self.assertRaises(KeyError):
             adapter["name"]
@@ -220,7 +220,7 @@ class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
     item_class_nested = ScrapySubclassedItemNested
 
     def test_get_value_keyerror_item_dict(self):
-        """Instantiate without default values"""
+        """Instantiate without default values."""
         adapter = ItemAdapter(self.item_class())
         with self.assertRaises(KeyError):
             adapter["name"]

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -24,9 +24,7 @@ class FakeItemClass:
 
 
 class BaseFakeItemAdapter(AdapterInterface):
-    """
-    An adapter that only implements the required methods
-    """
+    """An adapter that only implements the required methods."""
 
     @classmethod
     def is_item(cls, item: Any) -> bool:
@@ -58,18 +56,14 @@ class BaseFakeItemAdapter(AdapterInterface):
 
 
 class FieldNamesFakeItemAdapter(BaseFakeItemAdapter):
-    """
-    An adapter that also implements the field_names method
-    """
+    """An adapter that also implements the field_names method."""
 
     def field_names(self) -> KeysView:
         return KeysView({key.upper(): value for key, value in self.item._fields.items()})
 
 
 class MetadataFakeItemAdapter(BaseFakeItemAdapter):
-    """
-    An adapter that also implements the get_field_meta method
-    """
+    """An adapter that also implements the get_field_meta method."""
 
     def get_field_meta(self, field_name: str) -> MappingProxyType:
         if field_name in self.item._fields:
@@ -156,13 +150,13 @@ class BaseFakeItemAdapterTest(unittest.TestCase):
             del adapter["_undefined_"]
 
     def test_get_value_keyerror_item_dict(self):
-        """Instantiate without default values"""
+        """Instantiate without default values."""
         adapter = ItemAdapter(self.item_class())
         with self.assertRaises(KeyError):
             adapter["name"]
 
     def test_get_field_meta_defined_fields(self):
-        """Metadata is always empty for the default implementation"""
+        """Metadata is always empty for the default implementation."""
         adapter = ItemAdapter(self.item_class())
         self.assertEqual(adapter.get_field_meta("_undefined_"), MappingProxyType({}))
         self.assertEqual(adapter.get_field_meta("name"), MappingProxyType({}))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -189,9 +189,7 @@ except ImportError:
 
 
 class ScrapyDeprecatedBaseItemTestCase(unittest.TestCase):
-    """
-    Tests for deprecated classes. These will go away once the upstream classes are removed.
-    """
+    """Tests for deprecated classes. These will go away once the upstream classes are removed."""
 
     @unittest.skipIf(
         scrapy is None or not hasattr(scrapy.item, "_BaseItem"),
@@ -217,9 +215,7 @@ class ScrapyDeprecatedBaseItemTestCase(unittest.TestCase):
 
     @unittest.skipIf(scrapy is None, "scrapy module is not available")
     def test_removed_baseitem(self):
-        """
-        Mock the scrapy.item module so it does not contain the deprecated _BaseItem class
-        """
+        """Mock the scrapy.item module so it does not contain the deprecated _BaseItem class."""
 
         class MockItemModule:
             Item = ScrapyItem


### PR DESCRIPTION
Avoid the leading newline when accessing the docstring with `__doc__`.

Up until recently I have been putting leading newlines in my docstrings, thanks @Gallaecio for pointing me to [PEP 257](https://www.python.org/dev/peps/pep-0257).

