### PR TITLE
Implement support for Pydantic models

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The returned value is taken from the following sources, depending on the item ty
     for `dataclass`-based items
   * [`attr.Attribute.metadata`](https://www.attrs.org/en/stable/examples.html#metadata)
     for `attrs`-based items
+  * [`pydantic.fields.FieldInfo`](https://pydantic-docs.helpmanual.io/usage/schema/#field-customisation) for `pydantic`-based items
 
 #### `field_names() -> collections.abc.KeysView`
 
@@ -219,7 +220,7 @@ support field metadata, or there is no metadata for the given field, an empty ob
 
 ## Metadata support
 
-`scrapy.item.Item`, `dataclass` and `attrs` objects allow the definition of
+`scrapy.item.Item`, `dataclass`, `attrs`, and `pydantic` objects allow the definition of
 arbitrary field metadata. This can be accessed through a
 [`MappingProxyType`](https://docs.python.org/3/library/types.html#types.MappingProxyType)
 object, which can be retrieved from an item instance with the
@@ -269,6 +270,22 @@ mappingproxy({'serializer': <class 'int'>, 'limit': 100})
 ... class InventoryItem:
 ...     name = attr.ib(metadata={"serializer": str})
 ...     value = attr.ib(metadata={"serializer": int, "limit": 100})
+...
+>>> adapter = ItemAdapter(InventoryItem(name="foo", value=10))
+>>> adapter.get_field_meta("name")
+mappingproxy({'serializer': <class 'str'>})
+>>> adapter.get_field_meta("value")
+mappingproxy({'serializer': <class 'int'>, 'limit': 100})
+>>>
+```
+
+#### `pydantic` objects
+
+```python
+>>> from pydantic import BaseModel, Field
+>>> class InventoryItem(BaseModel):
+...     name: str = Field(serializer=str)
+...     value: int = Field(serializer=int, limit=100)
 ...
 >>> adapter = ItemAdapter(InventoryItem(name="foo", value=10))
 >>> adapter.get_field_meta("name")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently supported types are:
 * [`dict`](https://docs.python.org/3/library/stdtypes.html#dict)
 * [`dataclass`](https://docs.python.org/3/library/dataclasses.html)-based classes
 * [`attrs`](https://www.attrs.org)-based classes
+* [`pydantic`](https://pydantic-docs.helpmanual.io/)-based classes
 
 Additionally, interaction with arbitrary types is supported, by implementing
 a pre-defined interface (see [extending `itemadapter`](#extending-itemadapter)).
@@ -29,6 +30,7 @@ a pre-defined interface (see [extending `itemadapter`](#extending-itemadapter)).
   or its [backport](https://pypi.org/project/dataclasses/) in Python 3.6): optional, needed
   to interact with `dataclass`-based items
 * [`attrs`](https://pypi.org/project/attrs/): optional, needed to interact with `attrs`-based items
+* [`pydantic`](https://pypi.org/project/pydantic/): optional, needed to interact with `pydantic`-based items
 
 ---
 
@@ -139,6 +141,7 @@ The following adapters are included by default:
 * `itemadapter.adapter.DictAdapter`: handles `Python` dictionaries
 * `itemadapter.adapter.DataclassAdapter`: handles `dataclass` objects
 * `itemadapter.adapter.AttrsAdapter`: handles `attrs` objects
+* `itemadapter.adapter.PydanticAdapter`: handles `pydantic` objects
 
 ### class `itemadapter.adapter.ItemAdapter(item: Any)`
 
@@ -402,6 +405,28 @@ InventoryItem(name='bar', price=5)
 ... class InventoryItem:
 ...     name = attr.ib()
 ...     price = attr.ib()
+...
+>>> item = InventoryItem(name="foo", price=10)
+>>> adapter = ItemAdapter(item)
+>>> adapter.item is item
+True
+>>> adapter["name"]
+'foo'
+>>> adapter["name"] = "bar"
+>>> adapter["price"] = 5
+>>> item
+InventoryItem(name='bar', price=5)
+>>>
+```
+
+### `pydantic` objects
+
+```python
+>>> from pydantic import BaseModel
+>>> from itemadapter import ItemAdapter
+>>> class InventoryItem(BaseModel):
+...     name: str
+...     price: int
 ...
 >>> item = InventoryItem(name="foo", price=10)
 >>> adapter = ItemAdapter(item)

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -5,6 +5,7 @@ from types import MappingProxyType
 from typing import Any, Deque, Iterator, Type
 
 from itemadapter.utils import (
+    _get_pydantic_model_metadata,
     is_attrs_instance,
     is_dataclass_instance,
     is_item,
@@ -117,6 +118,9 @@ class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
 class PydanticAdapter(AdapterInterface):
 
     item: Any
+
+    def get_field_meta(self, field_name: str) -> MappingProxyType:
+        return _get_pydantic_model_metadata(type(self.item), field_name)
 
     @classmethod
     def is_item(cls, item: Any) -> bool:

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -121,10 +121,10 @@ class PydanticAdapter(AdapterInterface):
     @classmethod
     def is_item(cls, item: Any) -> bool:
         return is_pydantic_instance(item)
-    
+
     def field_names(self) -> KeysView:
         return KeysView(self.item.__fields__)
-    
+
     def __getitem__(self, field_name: str) -> Any:
         if field_name in self.item.__fields__:
             return getattr(self.item, field_name)

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -150,7 +150,7 @@ def get_field_meta_from_class(item_class: type, field_name: str) -> MappingProxy
             return _get_pydantic_model_metadata(item_class, field_name)
         except KeyError:
             raise KeyError("%s does not support field: %s" % (item_class.__name__, field_name))
-    elif issubclass(item_class, dict) or _is_pydantic_model(item_class):
+    elif issubclass(item_class, dict):
         return MappingProxyType({})
     else:
         raise TypeError("%s is not a valid item class" % (item_class,))

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -31,6 +31,14 @@ def _is_attrs_class(obj: Any) -> bool:
     return attr.has(obj)
 
 
+def _is_pydantic_model(obj: Any) -> bool:
+    try:
+        from pydantic import BaseModel
+    except ImportError:
+        return False
+    return issubclass(obj, BaseModel)
+
+
 def is_dataclass_instance(obj: Any) -> bool:
     """Return True if the given object is a dataclass object, False otherwise.
 
@@ -43,7 +51,7 @@ def is_dataclass_instance(obj: Any) -> bool:
 
 def is_pydantic_instance(obj: Any) -> bool:
     """Return True if the given object is a Pydantic model, False otherwise."""
-    return
+    return _is_pydantic_model(type(obj)) and not isinstance(obj, type)
 
 
 def is_attrs_instance(obj: Any) -> bool:
@@ -106,7 +114,7 @@ def get_field_meta_from_class(item_class: type, field_name: str) -> MappingProxy
             return fields_dict(item_class)[field_name].metadata  # type: ignore
         except KeyError:
             raise KeyError("%s does not support field: %s" % (item_class.__name__, field_name))
-    elif issubclass(item_class, dict):
+    elif issubclass(item_class, dict) or _is_pydantic_model(item_class):
         return MappingProxyType({})
     else:
         raise TypeError("%s is not a valid item class" % (item_class,))

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -40,15 +40,9 @@ def _is_pydantic_model(obj: Any) -> bool:
 
 
 def _get_pydantic_model_metadata(item_model: type, field_name: str) -> MappingProxyType:
-    from pydantic.fields import Undefined as PydanticUndefined
-
     metadata = {}
     field = item_model.__fields__[field_name].field_info
 
-    if field.default is not PydanticUndefined:
-        metadata["default"] = field.default
-    if not field.allow_mutation:
-        metadata["allow_mutation"] = field.allow_mutation
     for attr in [
         "alias",
         "title",
@@ -68,6 +62,8 @@ def _get_pydantic_model_metadata(item_model: type, field_name: str) -> MappingPr
         value = getattr(field, attr)
         if value is not None:
             metadata[attr] = value
+    if not field.allow_mutation:
+        metadata["allow_mutation"] = field.allow_mutation
     metadata.update(field.extra)
 
     return MappingProxyType(metadata)

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -39,6 +39,40 @@ def _is_pydantic_model(obj: Any) -> bool:
     return issubclass(obj, BaseModel)
 
 
+def _get_pydantic_model_metadata(item_model: type, field_name: str) -> MappingProxyType:
+    from pydantic.fields import Undefined as PydanticUndefined
+
+    metadata = {}
+    field = item_model.__fields__[field_name].field_info
+
+    if field.default is not PydanticUndefined:
+        metadata["default"] = field.default
+    if not field.allow_mutation:
+        metadata["allow_mutation"] = field.allow_mutation
+    for attr in [
+        "alias",
+        "title",
+        "description",
+        "const",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "multiple_of",
+        "min_items",
+        "max_items",
+        "min_length",
+        "max_length",
+        "regex",
+    ]:
+        value = getattr(field, attr)
+        if value is not None:
+            metadata[attr] = value
+    metadata.update(field.extra)
+
+    return MappingProxyType(metadata)
+
+
 def is_dataclass_instance(obj: Any) -> bool:
     """Return True if the given object is a dataclass object, False otherwise.
 
@@ -94,6 +128,7 @@ def get_field_meta_from_class(item_class: type, field_name: str) -> MappingProxy
     * scrapy.item.Item: corresponding scrapy.item.Field object
     * dataclass items: "metadata" attribute for the corresponding field
     * attrs items: "metadata" attribute for the corresponding field
+    * pydantic models: corresponding pydantic.field.FieldInfo/ModelField object
 
     The returned value is an instance of types.MappingProxyType, i.e. a dynamic read-only view
     of the original mapping, which gets automatically updated if the original mapping changes.
@@ -112,6 +147,11 @@ def get_field_meta_from_class(item_class: type, field_name: str) -> MappingProxy
 
         try:
             return fields_dict(item_class)[field_name].metadata  # type: ignore
+        except KeyError:
+            raise KeyError("%s does not support field: %s" % (item_class.__name__, field_name))
+    elif _is_pydantic_model(item_class):
+        try:
+            return _get_pydantic_model_metadata(item_class, field_name)
         except KeyError:
             raise KeyError("%s does not support field: %s" % (item_class.__name__, field_name))
     elif issubclass(item_class, dict) or _is_pydantic_model(item_class):

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -41,6 +41,11 @@ def is_dataclass_instance(obj: Any) -> bool:
     return _is_dataclass(obj) and not isinstance(obj, type)
 
 
+def is_pydantic_instance(obj: Any) -> bool:
+    """Return True if the given object is a Pydantic model, False otherwise."""
+    return
+
+
 def is_attrs_instance(obj: Any) -> bool:
     """Return True if the given object is a attrs-based object, False otherwise."""
     return _is_attrs_class(obj) and not isinstance(obj, type)

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -39,7 +39,7 @@ def _is_pydantic_model(obj: Any) -> bool:
     return issubclass(obj, BaseModel)
 
 
-def _get_pydantic_model_metadata(item_model: type, field_name: str) -> MappingProxyType:
+def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
     metadata = {}
     field = item_model.__fields__[field_name].field_info
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -62,15 +62,15 @@ else:
 
 
 try:
-    from pydantic import BaseModel, Field
+    from pydantic import BaseModel, Field as PydanticField
 except ImportError:
     PydanticModel = None
     PydanticModelNested = None
 else:
 
     class PydanticModel(BaseModel):
-        name: Optional[str] = Field(default_factory=lambda: None)
-        value: Optional[int] = Field(default_factory=lambda: None)
+        name: Optional[str] = PydanticField(default_factory=lambda: None)
+        value: Optional[int] = PydanticField(default_factory=lambda: None)
 
     class PydanticModelNested(BaseModel):
         nested: PydanticModel

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -69,8 +69,14 @@ except ImportError:
 else:
 
     class PydanticModel(BaseModel):
-        name: Optional[str] = PydanticField(default_factory=lambda: None, metadata={"serializer": str})
-        value: Optional[int] = PydanticField(default_factory=lambda: None, metadata={"serializer": int})
+        name: Optional[str] = PydanticField(
+            default_factory=lambda: None,
+            serializer=str,
+        )
+        value: Optional[int] = PydanticField(
+            default_factory=lambda: None,
+            serializer=int,
+        )
 
     class PydanticModelNested(BaseModel):
         nested: PydanticModel

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from itemadapter.adapter import ItemAdapter
 
 
@@ -57,6 +59,30 @@ else:
     class DataClassWithoutInit:
         name: str = field(metadata={"serializer": str})
         value: int = field(metadata={"serializer": int})
+
+
+try:
+    from pydantic import BaseModel, dataclasses, Field
+except ImportError:
+    PydanticModel = None
+    PydanticModelNested = None
+else:
+
+    class PydanticModel(BaseModel):
+        name: Optional[str] = Field(default_factory=lambda: None)
+        value: Optional[int] = Field(default_factory=lambda: None)
+    
+    class PydanticModelNested(BaseModel):
+        nested: PydanticModel
+        adapter: ItemAdapter
+        dict_: dict
+        list_: list
+        set_: set
+        tuple_: tuple
+        int_: int
+
+        class Config:
+            arbitrary_types_allowed = True
 
 
 try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -69,8 +69,8 @@ except ImportError:
 else:
 
     class PydanticModel(BaseModel):
-        name: Optional[str] = PydanticField(default_factory=lambda: None)
-        value: Optional[int] = PydanticField(default_factory=lambda: None)
+        name: Optional[str] = PydanticField(default_factory=lambda: None, metadata={"serializer": str})
+        value: Optional[int] = PydanticField(default_factory=lambda: None, metadata={"serializer": int})
 
     class PydanticModelNested(BaseModel):
         nested: PydanticModel

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -65,6 +65,7 @@ try:
     from pydantic import BaseModel, Field as PydanticField
 except ImportError:
     PydanticModel = None
+    PydanticSpecialCasesModel = None
     PydanticModelNested = None
 else:
 
@@ -77,6 +78,16 @@ else:
             default_factory=lambda: None,
             serializer=int,
         )
+
+    class PydanticSpecialCasesModel(BaseModel):
+        special_cases: Optional[int] = PydanticField(
+            default_factory=lambda: None,
+            alias="special_cases",
+            allow_mutation=False,
+        )
+
+        class Config:
+            validate_assignment = True
 
     class PydanticModelNested(BaseModel):
         nested: PydanticModel

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -62,7 +62,7 @@ else:
 
 
 try:
-    from pydantic import BaseModel, dataclasses, Field
+    from pydantic import BaseModel, Field
 except ImportError:
     PydanticModel = None
     PydanticModelNested = None
@@ -71,7 +71,7 @@ else:
     class PydanticModel(BaseModel):
         name: Optional[str] = Field(default_factory=lambda: None)
         value: Optional[int] = Field(default_factory=lambda: None)
-    
+
     class PydanticModelNested(BaseModel):
         nested: PydanticModel
         adapter: ItemAdapter

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 attrs
 dataclasses; python_version == "3.6"
+pydantic
 pytest-cov>=2.8
 pytest>=5.4
 scrapy>=2.0

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -11,6 +11,8 @@ from tests import (
     DataClassItem,
     DataClassItemNested,
     DataClassWithoutInit,
+    PydanticModel,
+    PydanticModelNested,
     ScrapySubclassedItem,
     ScrapySubclassedItemNested,
 )
@@ -66,6 +68,15 @@ class ItemAdapterReprTestCase(unittest.TestCase):
         adapter["name"] = "set after init"
         self.assertEqual(
             repr(adapter), "<ItemAdapter for AttrsItemWithoutInit(name='set after init')>"
+        )
+    
+    @unittest.skipIf(not PydanticModel, "pydantic module is not available")
+    def test_repr_pydantic(self):
+        item = PydanticModel(name="asdf", value=1234)
+        adapter = ItemAdapter(item)
+        self.assertEqual(
+            repr(adapter),
+            "<ItemAdapter for PydanticModel(name='asdf', value=1234)>",
         )
 
 
@@ -224,6 +235,12 @@ class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
         adapter = ItemAdapter(self.item_class())
         with self.assertRaises(KeyError):
             adapter["name"]
+
+
+class PydanticModelTestCase(NonDictTestMixin, unittest.TestCase):
+
+    item_class = PydanticModel
+    item_class_nested = PydanticModelNested
 
 
 class DataClassItemTestCase(NonDictTestMixin, unittest.TestCase):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -242,12 +242,6 @@ class PydanticModelTestCase(NonDictTestMixin, unittest.TestCase):
     item_class = PydanticModel
     item_class_nested = PydanticModelNested
 
-    def test_metadata_common(self):
-        pass
-
-    def test_get_field_meta_defined_fields(self):
-        pass
-
 
 class DataClassItemTestCase(NonDictTestMixin, unittest.TestCase):
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -241,6 +241,12 @@ class PydanticModelTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = PydanticModel
     item_class_nested = PydanticModelNested
+    
+    def test_metadata_common(self):
+        pass
+    
+    def test_get_field_meta_defined_fields(self):
+        pass
 
 
 class DataClassItemTestCase(NonDictTestMixin, unittest.TestCase):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -69,7 +69,7 @@ class ItemAdapterReprTestCase(unittest.TestCase):
         self.assertEqual(
             repr(adapter), "<ItemAdapter for AttrsItemWithoutInit(name='set after init')>"
         )
-    
+
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     def test_repr_pydantic(self):
         item = PydanticModel(name="asdf", value=1234)
@@ -241,10 +241,10 @@ class PydanticModelTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = PydanticModel
     item_class_nested = PydanticModelNested
-    
+
     def test_metadata_common(self):
         pass
-    
+
     def test_get_field_meta_defined_fields(self):
         pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,7 +66,7 @@ class ItemLikeTestCase(unittest.TestCase):
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
     def test_true_attrs(self):
         self.assertTrue(is_item(AttrsItem(name="asdf", value=1234)))
-    
+
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     def test_true_pydantic(self):
         self.assertTrue(is_item(PydanticModel(name="asdf", value=1234)))
@@ -170,14 +170,14 @@ class PydanticTestCase(unittest.TestCase):
         self.assertFalse(is_pydantic_instance(("a", "tuple")))
         self.assertFalse(is_pydantic_instance({"a", "set"}))
         self.assertFalse(is_pydantic_instance(PydanticModel))
-    
+
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     @mock.patch("builtins.__import__", mocked_import)
     def test_module_not_available(self):
         self.assertFalse(is_pydantic_instance(PydanticModel(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="PydanticModel is not a valid item class"):
             get_field_meta_from_class(PydanticModel, "name")
-    
+
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     def test_true(self):
         self.assertTrue(is_pydantic_instance(PydanticModel()))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -184,6 +184,14 @@ class PydanticTestCase(unittest.TestCase):
         self.assertTrue(is_pydantic_instance(PydanticModel(name="asdf", value=1234)))
         # field metadata
         self.assertEqual(
+            get_field_meta_from_class(PydanticModel, "name"),
+            MappingProxyType({"serializer": str}),
+        )
+        self.assertEqual(
+            get_field_meta_from_class(PydanticModel, "value"),
+            MappingProxyType({"serializer": int}),
+        )
+        self.assertEqual(
             get_field_meta_from_class(PydanticModel, "non_existent"),
             MappingProxyType({}),
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -183,8 +183,10 @@ class PydanticTestCase(unittest.TestCase):
         self.assertTrue(is_pydantic_instance(PydanticModel()))
         self.assertTrue(is_pydantic_instance(PydanticModel(name="asdf", value=1234)))
         # field metadata
-        with self.assertRaises(KeyError, msg="PydanticModel does not support field: non_existent"):
-            get_field_meta_from_class(PydanticModel, "non_existent")
+        self.assertEqual(
+            get_field_meta_from_class(PydanticModel, "non_existent"),
+            MappingProxyType({}),
+        )
 
 
 class ScrapyItemTestCase(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,14 @@ from itemadapter.utils import (
     is_scrapy_item,
 )
 
-from tests import AttrsItem, DataClassItem, PydanticModel, ScrapyItem, ScrapySubclassedItem
+from tests import (
+    AttrsItem,
+    DataClassItem,
+    PydanticModel,
+    PydanticSpecialCasesModel,
+    ScrapyItem,
+    ScrapySubclassedItem,
+)
 
 
 def mocked_import(name, *args, **kwargs):
@@ -190,6 +197,10 @@ class PydanticTestCase(unittest.TestCase):
         self.assertEqual(
             get_field_meta_from_class(PydanticModel, "value"),
             MappingProxyType({"serializer": int}),
+        )
+        self.assertEqual(
+            get_field_meta_from_class(PydanticSpecialCasesModel, "special_cases"),
+            MappingProxyType({"alias": "special_cases", "allow_mutation": False}),
         )
         with self.assertRaises(KeyError, msg="PydanticModel does not support field: non_existent"):
             get_field_meta_from_class(PydanticModel, "non_existent")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,10 +191,8 @@ class PydanticTestCase(unittest.TestCase):
             get_field_meta_from_class(PydanticModel, "value"),
             MappingProxyType({"serializer": int}),
         )
-        self.assertEqual(
-            get_field_meta_from_class(PydanticModel, "non_existent"),
-            MappingProxyType({}),
-        )
+        with self.assertRaises(KeyError, msg="PydanticModel does not support field: non_existent"):
+            get_field_meta_from_class(PydanticModel, "non_existent")
 
 
 class ScrapyItemTestCase(unittest.TestCase):


### PR DESCRIPTION
This pull request implements support for [Pydantic](https://pydantic-docs.helpmanual.io) models, including tests.

Coverage:
```
----------- coverage: platform win32, python 3.9.5-final-0 -----------
Name                      Stmts   Miss  Cover   Missing
-------------------------------------------------------
itemadapter\__init__.py       3      0   100%
itemadapter\adapter.py      158      0   100%
itemadapter\utils.py         69      0   100%
-------------------------------------------------------
TOTAL                       230      0   100%
```

If this is better suited for custom registration in my own projects than a pull request, I totally understand! I just saw requested it once already (#42) and thought that since it was a theme, a pull request might be useful.