### PR TITLE
[WIP] ItemAdapter.is_item_class and ItemAdapter.get_field_meta_from_class

### DIFF
--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -129,28 +129,7 @@ def get_field_meta_from_class(item_class: type, field_name: str) -> MappingProxy
     The returned value is an instance of types.MappingProxyType, i.e. a dynamic read-only view
     of the original mapping, which gets automatically updated if the original mapping changes.
     """
-    if issubclass(item_class, _get_scrapy_item_classes()):
-        return MappingProxyType(item_class.fields[field_name])  # type: ignore
-    elif _is_dataclass(item_class):
-        from dataclasses import fields
 
-        for field in fields(item_class):
-            if field.name == field_name:
-                return field.metadata  # type: ignore
-        raise KeyError("%s does not support field: %s" % (item_class.__name__, field_name))
-    elif _is_attrs_class(item_class):
-        from attr import fields_dict
+    from itemadapter.adapter import ItemAdapter
 
-        try:
-            return fields_dict(item_class)[field_name].metadata  # type: ignore
-        except KeyError:
-            raise KeyError("%s does not support field: %s" % (item_class.__name__, field_name))
-    elif _is_pydantic_model(item_class):
-        try:
-            return _get_pydantic_model_metadata(item_class, field_name)
-        except KeyError:
-            raise KeyError("%s does not support field: %s" % (item_class.__name__, field_name))
-    elif issubclass(item_class, dict):
-        return MappingProxyType({})
-    else:
-        raise TypeError("%s is not a valid item class" % (item_class,))
+    return ItemAdapter.get_field_meta_from_class(item_class, field_name)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -30,6 +30,10 @@ class BaseFakeItemAdapter(AdapterInterface):
     def is_item(cls, item: Any) -> bool:
         return isinstance(item, FakeItemClass)
 
+    @classmethod
+    def is_item_class(cls, item_class: type) -> bool:
+        return issubclass(item_class, FakeItemClass)
+
     def __getitem__(self, field_name: str) -> Any:
         if field_name in self.item._fields:
             return self.item._values[field_name]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import importlib
 import unittest
 from unittest import mock
 from types import MappingProxyType
@@ -22,6 +23,9 @@ from tests import (
 
 
 def mocked_import(name, *args, **kwargs):
+    """Allow only internal itemadapter imports."""
+    if name.split(".")[0] == "itemadapter":
+        return importlib.__import__(name, *args, **kwargs)
     raise ImportError(name)
 
 


### PR DESCRIPTION
Bringing in the ability to get field meta data for custom item classes. #53 showed us this is not currently possible without editing library code.

Tasks:
- [x] Code
- [ ] Tests (new tests and/or further adapt the existing ones)
- [ ] Docs