### PR TITLE
Avoid imports inside functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,20 +31,8 @@ jobs:
         ./codecov
 
   tests-other:
-    name: "Test: py3, ${{ matrix.os }}"
-    runs-on: "${{ matrix.os }}"
-    strategy:
-      matrix:
-        include:
-        - os: ubuntu-latest
-          env:
-            TOXENV: py38-scrapy22
-        - os: macos-latest
-          env:
-            TOXENV: py
-        - os: windows-latest
-          env:
-            TOXENV: py
+    name: "Test: py38-scrapy22, Ubuntu"
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -58,11 +46,31 @@ jobs:
       run: pip install tox
 
     - name: Run tests
-      env: ${{ matrix.env }}
-      run: tox
+      run: tox -e py38-scrapy22
 
     - name: Upload coverage report
       run: |
         curl -Os https://uploader.codecov.io/latest/linux/codecov
         chmod +x codecov
         ./codecov
+
+  tests-other-os:
+    name: "Test: py38, ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install tox
+      run: pip install tox
+
+    - name: Run tests
+      run: tox -e py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,4 +59,4 @@ jobs:
 
     - name: Run tests
       env: ${{ matrix.env }}
-      run: tox -e py
+      run: tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,10 @@ jobs:
       run: tox -e py
 
     - name: Upload coverage report
-      run: bash <(curl -s https://codecov.io/bash)
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov
 
   tests-other:
     name: "Test: py3, ${{ matrix.os }}"
@@ -33,23 +36,20 @@ jobs:
     strategy:
       matrix:
         include:
-        - python-version: 3
-          os: ubuntu-latest
+        - os: ubuntu-latest
           env:
             TOXENV: py38-scrapy22
-        - python-version: 3
-          os: macos-latest
+        - os: macos-latest
           env:
             TOXENV: py
-        - python-version: 3
-          os: windows-latest
+        - os: windows-latest
           env:
             TOXENV: py
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
@@ -60,3 +60,9 @@ jobs:
     - name: Run tests
       env: ${{ matrix.env }}
       run: tox
+
+    - name: Upload coverage report
+      run: |
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+        ./codecov

--- a/itemadapter/_imports.py
+++ b/itemadapter/_imports.py
@@ -1,10 +1,21 @@
 # attempt the following imports only once,
 # to be imported from itemadapter's submodules
 
+_scrapy_item_classes: tuple
+
 try:
     import scrapy  # pylint: disable=W0611 (unused-import)
 except ImportError:
     scrapy = None  # type: ignore [assignment]
+    _scrapy_item_classes = ()
+else:
+    try:
+        # handle deprecated base classes
+        _base_item_cls = getattr(scrapy.item, "_BaseItem", scrapy.item.BaseItem)
+    except AttributeError:
+        _scrapy_item_classes = (scrapy.item.Item,)
+    else:
+        _scrapy_item_classes = (scrapy.item.Item, _base_item_cls)
 
 try:
     import dataclasses  # pylint: disable=W0611 (unused-import)

--- a/itemadapter/_imports.py
+++ b/itemadapter/_imports.py
@@ -1,0 +1,22 @@
+# attempt the following imports only once,
+# to be imported from itemadapter's submodules
+
+try:
+    import scrapy  # pylint: disable=W0611 (unused-import)
+except ImportError:
+    scrapy = None  # type: ignore [assignment]
+
+try:
+    import dataclasses  # pylint: disable=W0611 (unused-import)
+except ImportError:
+    dataclasses = None  # type: ignore [assignment]
+
+try:
+    import attr  # pylint: disable=W0611 (unused-import)
+except ImportError:
+    attr = None  # type: ignore [assignment]
+
+try:
+    import pydantic  # pylint: disable=W0611 (unused-import)
+except ImportError:
+    pydantic = None  # type: ignore [assignment]

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -218,6 +218,10 @@ class _MixinDictScrapyItemAdapter:
 
 class DictAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
     @classmethod
+    def is_item(cls, item: Any) -> bool:
+        return isinstance(item, dict)
+
+    @classmethod
     def is_item_class(cls, item_class: type) -> bool:
         return issubclass(item_class, dict)
 
@@ -226,6 +230,10 @@ class DictAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
 
 
 class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
+    @classmethod
+    def is_item(cls, item: Any) -> bool:
+        return isinstance(item, _scrapy_item_classes)
+
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
         return issubclass(item_class, _scrapy_item_classes)

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -6,13 +6,12 @@ from typing import Any, Deque, Iterator, Type
 
 from itemadapter.utils import (
     _get_pydantic_model_metadata,
-    _get_scrapy_item_classes,
     _is_attrs_class,
     _is_dataclass,
     _is_pydantic_model,
 )
 
-from itemadapter._imports import attr, dataclasses
+from itemadapter._imports import attr, dataclasses, _scrapy_item_classes
 
 
 __all__ = [
@@ -229,7 +228,7 @@ class DictAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
 class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
-        return issubclass(item_class, _get_scrapy_item_classes())
+        return issubclass(item_class, _scrapy_item_classes)
 
     @classmethod
     def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -3,21 +3,10 @@ import warnings
 from types import MappingProxyType
 from typing import Any
 
-from itemadapter._imports import attr, dataclasses, pydantic, scrapy
+from itemadapter._imports import attr, dataclasses, pydantic
+
 
 __all__ = ["is_item", "get_field_meta_from_class"]
-
-
-def _get_scrapy_item_classes() -> tuple:
-    if scrapy is None:
-        return ()
-    try:
-        # handle deprecated base classes
-        _base_item_cls = getattr(scrapy.item, "_BaseItem", scrapy.item.BaseItem)
-    except AttributeError:
-        return (scrapy.item.Item,)
-    else:
-        return (scrapy.item.Item, _base_item_cls)
 
 
 def _is_dataclass(obj: Any) -> bool:

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -3,28 +3,9 @@ import warnings
 from types import MappingProxyType
 from typing import Any
 
+from itemadapter._imports import attr, dataclasses, pydantic, scrapy
 
 __all__ = ["is_item", "get_field_meta_from_class"]
-
-try:
-    import scrapy
-except ImportError:
-    scrapy = None  # type: ignore [assignment]
-
-try:
-    import dataclasses
-except ImportError:
-    dataclasses = None  # type: ignore [assignment]
-
-try:
-    import attr
-except ImportError:
-    attr = None  # type: ignore [assignment]
-
-try:
-    import pydantic
-except ImportError:
-    pydantic = None  # type: ignore [assignment]
 
 
 def _get_scrapy_item_classes() -> tuple:

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -6,51 +6,62 @@ from typing import Any
 
 __all__ = ["is_item", "get_field_meta_from_class"]
 
+try:
+    import scrapy
+except ImportError:
+    scrapy = None  # type: ignore [assignment]
+
+try:
+    import dataclasses
+except ImportError:
+    dataclasses = None  # type: ignore [assignment]
+
+try:
+    import attr
+except ImportError:
+    attr = None  # type: ignore [assignment]
+
+try:
+    import pydantic
+except ImportError:
+    pydantic = None  # type: ignore [assignment]
+
 
 def _get_scrapy_item_classes() -> tuple:
-    try:
-        import scrapy
-    except ImportError:
+    if scrapy is None:
         return ()
-    else:
-        try:
-            # handle deprecated base classes
-            _base_item_cls = getattr(scrapy.item, "_BaseItem", scrapy.item.BaseItem)
-            return (scrapy.item.Item, _base_item_cls)
-        except AttributeError:
-            return (scrapy.item.Item,)
+    try:
+        # handle deprecated base classes
+        _base_item_cls = getattr(scrapy.item, "_BaseItem", scrapy.item.BaseItem)
+        return (scrapy.item.Item, _base_item_cls)
+    except AttributeError:
+        return (scrapy.item.Item,)
 
 
 def _is_dataclass(obj: Any) -> bool:
     """In py36, this returns False if the "dataclasses" backport module is not installed."""
-    try:
-        import dataclasses
-    except ImportError:
+    if dataclasses is None:
         return False
     return dataclasses.is_dataclass(obj)
 
 
 def _is_attrs_class(obj: Any) -> bool:
-    try:
-        import attr
-    except ImportError:
+    if attr is None:
         return False
     return attr.has(obj)
 
 
 def _is_pydantic_model(obj: Any) -> bool:
-    try:
-        from pydantic import BaseModel
-    except ImportError:
+    if pydantic is None:
         return False
-    return issubclass(obj, BaseModel)
+    return issubclass(obj, pydantic.BaseModel)
 
 
 def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
     metadata = {}
     field = item_model.__fields__[field_name].field_info
 
-    for attr in [
+    for attribute in [
         "alias",
         "title",
         "description",
@@ -66,9 +77,9 @@ def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingPro
         "max_length",
         "regex",
     ]:
-        value = getattr(field, attr)
+        value = getattr(field, attribute)
         if value is not None:
-            metadata[attr] = value
+            metadata[attribute] = value
     if not field.allow_mutation:
         metadata["allow_mutation"] = field.allow_mutation
     metadata.update(field.extra)

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -30,14 +30,13 @@ except ImportError:
 def _get_scrapy_item_classes() -> tuple:
     if scrapy is None:
         return ()
+    try:
+        # handle deprecated base classes
+        _base_item_cls = getattr(scrapy.item, "_BaseItem", scrapy.item.BaseItem)
+    except AttributeError:
+        return (scrapy.item.Item,)
     else:
-        try:
-            # handle deprecated base classes
-            _base_item_cls = getattr(scrapy.item, "_BaseItem", scrapy.item.BaseItem)
-        except AttributeError:
-            return (scrapy.item.Item,)
-        else:
-            return (scrapy.item.Item, _base_item_cls)
+        return (scrapy.item.Item, _base_item_cls)
 
 
 def _is_dataclass(obj: Any) -> bool:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,14 +1,6 @@
-import importlib
 from typing import Optional
 
 from itemadapter import ItemAdapter
-
-
-def mocked_import(name, *args, **kwargs):
-    """Allow only internal itemadapter imports."""
-    if name.split(".")[0] == "itemadapter":
-        return importlib.__import__(name, *args, **kwargs)
-    raise ImportError(name)
 
 
 try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,31 @@
-from typing import Optional
+import importlib
+import sys
+from contextlib import contextmanager
+from typing import Callable, Optional
 
 from itemadapter import ItemAdapter
+
+
+def make_mock_import(block_name: str) -> Callable:
+    def mock_import(name: str, *args, **kwargs):
+        """Prevent importing a specific module, let everything else pass."""
+        if name.split(".")[0] == block_name:
+            raise ImportError(name)
+        return importlib.__import__(name, *args, **kwargs)
+
+    return mock_import
+
+
+@contextmanager
+def clear_itemadapter_imports() -> None:
+    backup = {}
+    for key in sys.modules.copy().keys():
+        if key.startswith("itemadapter"):
+            backup[key] = sys.modules.pop(key)
+    try:
+        yield
+    finally:
+        sys.modules.update(backup)
 
 
 try:

--- a/tests/test_adapter_attrs.py
+++ b/tests/test_adapter_attrs.py
@@ -12,7 +12,6 @@ from tests import (
     PydanticModel,
     ScrapyItem,
     ScrapySubclassedItem,
-    mocked_import,
 )
 
 
@@ -35,7 +34,7 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(AttrsAdapter.is_item(AttrsItem))
 
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
+    @mock.patch("itemadapter.utils.attr", None)
     def test_module_not_available(self):
         self.assertFalse(AttrsAdapter.is_item(AttrsItem(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="AttrsItem is not a valid item class"):

--- a/tests/test_adapter_attrs.py
+++ b/tests/test_adapter_attrs.py
@@ -43,6 +43,10 @@ class AttrsTestCase(unittest.TestCase):
             from itemadapter.adapter import AttrsAdapter
 
             self.assertFalse(AttrsAdapter.is_item(AttrsItem(name="asdf", value=1234)))
+            with self.assertRaises(RuntimeError, msg="attr module is not available"):
+                AttrsAdapter(AttrsItem(name="asdf", value=1234))
+            with self.assertRaises(RuntimeError, msg="attr module is not available"):
+                AttrsAdapter.get_field_meta_from_class(AttrsItem, "name")
             with self.assertRaises(TypeError, msg="AttrsItem is not a valid item class"):
                 get_field_meta_from_class(AttrsItem, "name")
 

--- a/tests/test_adapter_attrs.py
+++ b/tests/test_adapter_attrs.py
@@ -3,7 +3,6 @@ import warnings
 from types import MappingProxyType
 from unittest import mock
 
-from itemadapter.adapter import AttrsAdapter
 from itemadapter.utils import get_field_meta_from_class
 
 from tests import (
@@ -12,11 +11,15 @@ from tests import (
     PydanticModel,
     ScrapyItem,
     ScrapySubclassedItem,
+    make_mock_import,
+    clear_itemadapter_imports,
 )
 
 
 class AttrsTestCase(unittest.TestCase):
     def test_false(self):
+        from itemadapter.adapter import AttrsAdapter
+
         self.assertFalse(AttrsAdapter.is_item(int))
         self.assertFalse(AttrsAdapter.is_item(sum))
         self.assertFalse(AttrsAdapter.is_item(1234))
@@ -34,14 +37,28 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(AttrsAdapter.is_item(AttrsItem))
 
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
+    @mock.patch("builtins.__import__", make_mock_import("attr"))
+    def test_module_import_error(self):
+        with clear_itemadapter_imports():
+            from itemadapter.adapter import AttrsAdapter
+
+            self.assertFalse(AttrsAdapter.is_item(AttrsItem(name="asdf", value=1234)))
+            with self.assertRaises(TypeError, msg="AttrsItem is not a valid item class"):
+                get_field_meta_from_class(AttrsItem, "name")
+
+    @unittest.skipIf(not AttrsItem, "attrs module is not available")
     @mock.patch("itemadapter.utils.attr", None)
     def test_module_not_available(self):
+        from itemadapter.adapter import AttrsAdapter
+
         self.assertFalse(AttrsAdapter.is_item(AttrsItem(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="AttrsItem is not a valid item class"):
             get_field_meta_from_class(AttrsItem, "name")
 
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
     def test_true(self):
+        from itemadapter.adapter import AttrsAdapter
+
         self.assertTrue(AttrsAdapter.is_item(AttrsItem()))
         self.assertTrue(AttrsAdapter.is_item(AttrsItem(name="asdf", value=1234)))
         # field metadata

--- a/tests/test_adapter_dataclasses.py
+++ b/tests/test_adapter_dataclasses.py
@@ -43,6 +43,10 @@ class DataclassTestCase(unittest.TestCase):
             from itemadapter.adapter import DataclassAdapter
 
             self.assertFalse(DataclassAdapter.is_item(DataClassItem(name="asdf", value=1234)))
+            with self.assertRaises(RuntimeError, msg="attr module is not available"):
+                DataclassAdapter(DataClassItem(name="asdf", value=1234))
+            with self.assertRaises(RuntimeError, msg="attr module is not available"):
+                DataclassAdapter.get_field_meta_from_class(DataClassItem, "name")
             with self.assertRaises(TypeError, msg="DataClassItem is not a valid item class"):
                 get_field_meta_from_class(DataClassItem, "name")
 

--- a/tests/test_adapter_dataclasses.py
+++ b/tests/test_adapter_dataclasses.py
@@ -12,7 +12,6 @@ from tests import (
     PydanticModel,
     ScrapyItem,
     ScrapySubclassedItem,
-    mocked_import,
 )
 
 
@@ -35,7 +34,7 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(DataclassAdapter.is_item(DataClassItem))
 
     @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
+    @mock.patch("itemadapter.utils.dataclasses", None)
     def test_module_not_available(self):
         self.assertFalse(DataclassAdapter.is_item(DataClassItem(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="DataClassItem is not a valid item class"):

--- a/tests/test_adapter_pydantic.py
+++ b/tests/test_adapter_pydantic.py
@@ -13,7 +13,6 @@ from tests import (
     PydanticSpecialCasesModel,
     ScrapyItem,
     ScrapySubclassedItem,
-    mocked_import,
 )
 
 
@@ -36,7 +35,7 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(PydanticAdapter.is_item(PydanticModel))
 
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
+    @mock.patch("itemadapter.utils.pydantic", None)
     def test_module_not_available(self):
         self.assertFalse(PydanticAdapter.is_item(PydanticModel(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="PydanticModel is not a valid item class"):

--- a/tests/test_adapter_pydantic.py
+++ b/tests/test_adapter_pydantic.py
@@ -3,7 +3,6 @@ import warnings
 from types import MappingProxyType
 from unittest import mock
 
-from itemadapter.adapter import PydanticAdapter
 from itemadapter.utils import get_field_meta_from_class
 
 from tests import (
@@ -13,11 +12,15 @@ from tests import (
     PydanticSpecialCasesModel,
     ScrapyItem,
     ScrapySubclassedItem,
+    make_mock_import,
+    clear_itemadapter_imports,
 )
 
 
 class DataclassTestCase(unittest.TestCase):
     def test_false(self):
+        from itemadapter.adapter import PydanticAdapter
+
         self.assertFalse(PydanticAdapter.is_item(int))
         self.assertFalse(PydanticAdapter.is_item(sum))
         self.assertFalse(PydanticAdapter.is_item(1234))
@@ -35,14 +38,28 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(PydanticAdapter.is_item(PydanticModel))
 
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
+    @mock.patch("builtins.__import__", make_mock_import("pydantic"))
+    def test_module_import_error(self):
+        with clear_itemadapter_imports():
+            from itemadapter.adapter import PydanticAdapter
+
+            self.assertFalse(PydanticAdapter.is_item(PydanticModel(name="asdf", value=1234)))
+            with self.assertRaises(TypeError, msg="PydanticModel is not a valid item class"):
+                get_field_meta_from_class(PydanticModel, "name")
+
+    @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     @mock.patch("itemadapter.utils.pydantic", None)
     def test_module_not_available(self):
+        from itemadapter.adapter import PydanticAdapter
+
         self.assertFalse(PydanticAdapter.is_item(PydanticModel(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="PydanticModel is not a valid item class"):
             get_field_meta_from_class(PydanticModel, "name")
 
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     def test_true(self):
+        from itemadapter.adapter import PydanticAdapter
+
         self.assertTrue(PydanticAdapter.is_item(PydanticModel()))
         self.assertTrue(PydanticAdapter.is_item(PydanticModel(name="asdf", value=1234)))
         # field metadata

--- a/tests/test_adapter_scrapy.py
+++ b/tests/test_adapter_scrapy.py
@@ -50,7 +50,7 @@ class ScrapyItemTestCase(unittest.TestCase):
                 get_field_meta_from_class(ScrapySubclassedItem, "name")
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
-    @mock.patch("itemadapter.utils.scrapy", None)
+    @mock.patch("itemadapter.adapter._scrapy_item_classes", ())
     def test_module_not_available(self):
         from itemadapter.adapter import ScrapyItemAdapter
 

--- a/tests/test_adapter_scrapy.py
+++ b/tests/test_adapter_scrapy.py
@@ -12,7 +12,6 @@ from tests import (
     PydanticModel,
     ScrapyItem,
     ScrapySubclassedItem,
-    mocked_import,
 )
 
 
@@ -34,7 +33,7 @@ class ScrapyItemTestCase(unittest.TestCase):
         self.assertFalse(ScrapyItemAdapter.is_item(ScrapySubclassedItem))
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
-    @mock.patch("builtins.__import__", mocked_import)
+    @mock.patch("itemadapter.utils.scrapy", None)
     def test_module_not_available(self):
         self.assertFalse(ScrapyItemAdapter.is_item(ScrapySubclassedItem(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="ScrapySubclassedItem is not a valid item class"):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = bandit,flake8,typing,black,py,pylint
+envlist = bandit,flake8,typing,black,py,py38-scrapy22,pylint
 
 [testenv]
 deps =
     -rtests/requirements.txt
+    py38-scrapy22: scrapy==2.2
 commands =
     pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --doctest-glob=README.md {posargs: itemadapter README.md tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,10 @@ commands =
 [testenv:typing]
 basepython = python3
 deps =
-    mypy==0.770
+    mypy==0.941
 commands =
-    mypy --show-error-codes --ignore-missing-imports --follow-imports=skip {posargs:itemadapter}
+    mypy --install-types --non-interactive \
+        --show-error-codes --ignore-missing-imports --follow-imports=skip {posargs:itemadapter}
 
 [testenv:black]
 basepython = python3


### PR DESCRIPTION
Related to #59 (not sure if it fixes it completely)

Tasks:
- [x] Restore test coverage (the solution I found is a bit hacky: blocking some imports, also deleting them from `sys.modules` if they were imported already)
- [x] Remove additional non top-level imports in `itemadapter.adapter` 