### PR TITLE
Improve performance

### DIFF
--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -271,13 +271,17 @@ class ItemAdapter(MutableMapping):
 
     @classmethod
     def is_item(cls, item: Any) -> bool:
-        return any(adapter_class.is_item(item) for adapter_class in cls.ADAPTER_CLASSES)
+        for adapter_class in cls.ADAPTER_CLASSES:
+            if adapter_class.is_item(item):
+                return True
+        return False
 
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
-        return any(
-            adapter_class.is_item_class(item_class) for adapter_class in cls.ADAPTER_CLASSES
-        )
+        for adapter_class in cls.ADAPTER_CLASSES:
+            if adapter_class.is_item_class(item_class):
+                return True
+        return False
 
     @classmethod
     def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:


### PR DESCRIPTION
Try to keep improving performance after #60.

It's my understanding that `any` is short-circuit, however there seems to some penalty. Using a modified version of [this benchmarking script](https://github.com/scrapy/itemadapter/pull/60#issuecomment-1070836036):
```python
from timeit import timeit
from itemadapter import is_item
from scrapy.item import Item

def test_dict():
    return is_item({})

def test_item():
    return is_item(Item())

print("test_dict:", timeit(test_dict, number=10**6))
print("test_item:", timeit(test_item, number=10**6))
```

1203b5e54ad75c50279f8bbee05837a6f0c1d63c
```
test_dict: 2.421997083
test_item: 3.901377961
```

873301421945cc80ee6d5fd95969203b5b2cae2e
```
test_dict: 1.6679764910000001
test_item: 3.0513542609999997
```

The above numbers are from a 2020 Macbook Pro, Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz