### PR TITLE
ItemAdapter.get_field_names_from_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ The returned value is taken from the following sources, depending on the item ty
   * [`pydantic.fields.FieldInfo`](https://pydantic-docs.helpmanual.io/usage/schema/#field-customisation)
     for `pydantic`-based items
 
+#### class method `get_field_names_from_class(item_class: type) -> Optional[list[str]]`
+
+Return a list with the names of all the fields defined for the item class.
+If an item class doesn't support defining fields upfront, None is returned.
+
 #### `get_field_meta(field_name: str) -> MappingProxyType`
 
 Return metadata for the given field, if available. Unless overriden in a custom adapter class, by default

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -164,7 +164,7 @@ class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
     @classmethod
     def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
         if dataclasses is None:
-            raise RuntimeError("attr module is not available")
+            raise RuntimeError("dataclasses module is not available")
         return [a.name for a in dataclasses.fields(item_class)]
 
 

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -2,7 +2,7 @@ from abc import abstractmethod, ABCMeta
 from collections import deque
 from collections.abc import KeysView, MutableMapping
 from types import MappingProxyType
-from typing import Any, Deque, Iterator, Type
+from typing import Any, Deque, Iterator, Type, Optional, List
 
 from itemadapter.utils import (
     _get_pydantic_model_metadata,
@@ -50,6 +50,12 @@ class AdapterInterface(MutableMapping, metaclass=ABCMeta):
     @classmethod
     def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:
         return MappingProxyType({})
+
+    @classmethod
+    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
+        """Return a list of fields defined for ``item_class``.
+        If a class doesn't support fields, None is returned."""
+        return None
 
     def get_field_meta(self, field_name: str) -> MappingProxyType:
         """Return metadata for the given field name, if available."""
@@ -123,6 +129,12 @@ class AttrsAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
         except KeyError:
             raise KeyError(f"{item_class.__name__} does not support field: {field_name}")
 
+    @classmethod
+    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
+        if attr is None:
+            raise RuntimeError("attr module is not available")
+        return [a.name for a in attr.fields(item_class)]
+
 
 class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
     def __init__(self, item: Any) -> None:
@@ -149,6 +161,12 @@ class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
                 return field.metadata  # type: ignore
         raise KeyError(f"{item_class.__name__} does not support field: {field_name}")
 
+    @classmethod
+    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
+        if dataclasses is None:
+            raise RuntimeError("attr module is not available")
+        return [a.name for a in dataclasses.fields(item_class)]
+
 
 class PydanticAdapter(AdapterInterface):
 
@@ -164,6 +182,10 @@ class PydanticAdapter(AdapterInterface):
             return _get_pydantic_model_metadata(item_class, field_name)
         except KeyError:
             raise KeyError(f"{item_class.__name__} does not support field: {field_name}")
+
+    @classmethod
+    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
+        return list(item_class.__fields__.keys())  # type: ignore[attr-defined]
 
     def field_names(self) -> KeysView:
         return KeysView(self.item.__fields__)
@@ -240,7 +262,11 @@ class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
 
     @classmethod
     def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:
-        return MappingProxyType(item_class.fields[field_name])  # type: ignore
+        return MappingProxyType(item_class.fields[field_name])  # type: ignore[attr-defined]
+
+    @classmethod
+    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
+        return list(item_class.fields.keys())  # type: ignore[attr-defined]
 
     def field_names(self) -> KeysView:
         return KeysView(self.item.fields)
@@ -284,11 +310,21 @@ class ItemAdapter(MutableMapping):
         return False
 
     @classmethod
-    def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:
+    def _get_adapter_class(cls, item_class: type) -> Type[AdapterInterface]:
         for adapter_class in cls.ADAPTER_CLASSES:
             if adapter_class.is_item_class(item_class):
-                return adapter_class.get_field_meta_from_class(item_class, field_name)
+                return adapter_class
         raise TypeError(f"{item_class} is not a valid item class")
+
+    @classmethod
+    def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:
+        adapter_class = cls._get_adapter_class(item_class)
+        return adapter_class.get_field_meta_from_class(item_class, field_name)
+
+    @classmethod
+    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
+        adapter_class = cls._get_adapter_class(item_class)
+        return adapter_class.get_field_names_from_class(item_class)
 
     @property
     def item(self) -> Any:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,6 +34,8 @@ except ImportError:
     AttrsItem = None
     AttrsItemNested = None
     AttrsItemWithoutInit = None
+    AttrsItemSubclassed = None
+    AttrsItemEmpty = None
 else:
 
     @attr.s
@@ -56,6 +58,14 @@ else:
         name = attr.ib(default=None, metadata={"serializer": str})
         value = attr.ib(default=None, metadata={"serializer": int})
 
+    @attr.s(init=False)
+    class AttrsItemSubclassed(AttrsItem):
+        subclassed = attr.ib(default=True, type=bool)
+
+    @attr.s
+    class AttrsItemEmpty:
+        pass
+
 
 try:
     from dataclasses import dataclass, field
@@ -63,6 +73,8 @@ except ImportError:
     DataClassItem = None
     DataClassItemNested = None
     DataClassWithoutInit = None
+    DataClassItemSubclassed = None
+    DataClassItemEmpty = None
 else:
 
     @dataclass
@@ -85,6 +97,14 @@ else:
         name: str = field(metadata={"serializer": str})
         value: int = field(metadata={"serializer": int})
 
+    @dataclass
+    class DataClassItemSubclassed(DataClassItem):
+        subclassed: bool = True
+
+    @dataclass
+    class DataClassItemEmpty:
+        pass
+
 
 try:
     from pydantic import BaseModel, Field as PydanticField
@@ -92,6 +112,8 @@ except ImportError:
     PydanticModel = None
     PydanticSpecialCasesModel = None
     PydanticModelNested = None
+    PydanticModelSubclassed = None
+    PydanticModelEmpty = None
 else:
 
     class PydanticModel(BaseModel):
@@ -126,6 +148,14 @@ else:
         class Config:
             arbitrary_types_allowed = True
 
+    class PydanticModelSubclassed(PydanticModel):
+        subclassed: bool = PydanticField(
+            default_factory=lambda: True,
+        )
+
+    class PydanticModelEmpty(BaseModel):
+        pass
+
 
 try:
     from scrapy.item import Item as ScrapyItem, Field
@@ -133,6 +163,8 @@ except ImportError:
     ScrapyItem = None
     ScrapySubclassedItem = None
     ScrapySubclassedItemNested = None
+    ScrapySubclassedItemSubclassed = None
+    ScrapySubclassedItemEmpty = None
 else:
 
     class ScrapySubclassedItem(ScrapyItem):
@@ -147,3 +179,9 @@ else:
         set_ = Field()
         tuple_ = Field()
         int_ = Field()
+
+    class ScrapySubclassedItemSubclassed(ScrapySubclassedItem):
+        subclassed = Field()
+
+    class ScrapySubclassedItemEmpty(ScrapyItem):
+        pass

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -8,13 +8,21 @@ from tests import (
     AttrsItem,
     AttrsItemNested,
     AttrsItemWithoutInit,
+    AttrsItemSubclassed,
+    AttrsItemEmpty,
     DataClassItem,
     DataClassItemNested,
     DataClassWithoutInit,
+    DataClassItemSubclassed,
+    DataClassItemEmpty,
     PydanticModel,
     PydanticModelNested,
+    PydanticModelSubclassed,
+    PydanticModelEmpty,
     ScrapySubclassedItem,
     ScrapySubclassedItemNested,
+    ScrapySubclassedItemSubclassed,
+    ScrapySubclassedItemEmpty,
 )
 
 
@@ -161,6 +169,9 @@ class BaseTestMixin:
 
 
 class NonDictTestMixin(BaseTestMixin):
+    item_class_subclassed = None
+    item_class_empty = None
+
     def test_set_value_keyerror(self):
         item = self.item_class()
         adapter = ItemAdapter(item)
@@ -200,6 +211,21 @@ class NonDictTestMixin(BaseTestMixin):
         with self.assertRaises(KeyError):
             del adapter["undefined_field"]
 
+    def test_field_names_from_class(self):
+        field_names = ItemAdapter.get_field_names_from_class(self.item_class)
+        assert isinstance(field_names, list)
+        self.assertEqual(sorted(field_names), ["name", "value"])
+
+    def test_field_names_from_class_nested(self):
+        field_names = ItemAdapter.get_field_names_from_class(self.item_class_subclassed)
+        assert isinstance(field_names, list)
+        self.assertEqual(sorted(field_names), ["name", "subclassed", "value"])
+
+    def test_field_names_from_class_empty(self):
+        field_names = ItemAdapter.get_field_names_from_class(self.item_class_empty)
+        assert isinstance(field_names, list)
+        self.assertEqual(field_names, [])
+
 
 class DictTestCase(unittest.TestCase, BaseTestMixin):
 
@@ -224,11 +250,16 @@ class DictTestCase(unittest.TestCase, BaseTestMixin):
         item["value"] = 1234
         self.assertEqual(sorted(field_names), ["name", "value"])
 
+    def test_field_names_from_class(self):
+        assert ItemAdapter.get_field_names_from_class(dict) is None
+
 
 class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = ScrapySubclassedItem
     item_class_nested = ScrapySubclassedItemNested
+    item_class_subclassed = ScrapySubclassedItemSubclassed
+    item_class_empty = ScrapySubclassedItemEmpty
 
     def test_get_value_keyerror_item_dict(self):
         """Instantiate without default values."""
@@ -241,15 +272,21 @@ class PydanticModelTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = PydanticModel
     item_class_nested = PydanticModelNested
+    item_class_subclassed = PydanticModelSubclassed
+    item_class_empty = PydanticModelEmpty
 
 
 class DataClassItemTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = DataClassItem
     item_class_nested = DataClassItemNested
+    item_class_subclassed = DataClassItemSubclassed
+    item_class_empty = DataClassItemEmpty
 
 
 class AttrsItemTestCase(NonDictTestMixin, unittest.TestCase):
 
     item_class = AttrsItem
     item_class_nested = AttrsItemNested
+    item_class_subclassed = AttrsItemSubclassed
+    item_class_empty = AttrsItemEmpty

--- a/tests/test_adapter_attrs.py
+++ b/tests/test_adapter_attrs.py
@@ -47,6 +47,8 @@ class AttrsTestCase(unittest.TestCase):
                 AttrsAdapter(AttrsItem(name="asdf", value=1234))
             with self.assertRaises(RuntimeError, msg="attr module is not available"):
                 AttrsAdapter.get_field_meta_from_class(AttrsItem, "name")
+            with self.assertRaises(RuntimeError, msg="attr module is not available"):
+                AttrsAdapter.get_field_names_from_class(AttrsItem)
             with self.assertRaises(TypeError, msg="AttrsItem is not a valid item class"):
                 get_field_meta_from_class(AttrsItem, "name")
 

--- a/tests/test_adapter_dataclasses.py
+++ b/tests/test_adapter_dataclasses.py
@@ -43,10 +43,13 @@ class DataclassTestCase(unittest.TestCase):
             from itemadapter.adapter import DataclassAdapter
 
             self.assertFalse(DataclassAdapter.is_item(DataClassItem(name="asdf", value=1234)))
-            with self.assertRaises(RuntimeError, msg="attr module is not available"):
+            with self.assertRaises(RuntimeError, msg="dataclasses module is not available"):
                 DataclassAdapter(DataClassItem(name="asdf", value=1234))
-            with self.assertRaises(RuntimeError, msg="attr module is not available"):
+            with self.assertRaises(RuntimeError, msg="dataclasses module is not available"):
                 DataclassAdapter.get_field_meta_from_class(DataClassItem, "name")
+            with self.assertRaises(RuntimeError, msg="dataclasses module is not available"):
+                DataclassAdapter.get_field_names_from_class(DataClassItem)
+
             with self.assertRaises(TypeError, msg="DataClassItem is not a valid item class"):
                 get_field_meta_from_class(DataClassItem, "name")
 


### PR DESCRIPTION
hey! This PR adds a new ItemAdapter classmethod: get_field_names_from_class - similar to get_field_names, but accepts item class, not an item itself. It's motivated by https://github.com/scrapinghub/web-poet/pull/53#discussion_r934313210.
 