### PR TITLE
Simplify dataclass tests

### DIFF
--- a/itemadapter/_imports.py
+++ b/itemadapter/_imports.py
@@ -18,11 +18,6 @@ else:
         _scrapy_item_classes = (scrapy.item.Item, _base_item_cls)
 
 try:
-    import dataclasses  # pylint: disable=W0611 (unused-import)
-except ImportError:
-    dataclasses = None  # type: ignore [assignment]
-
-try:
     import attr  # pylint: disable=W0611 (unused-import)
 except ImportError:
     attr = None  # type: ignore [assignment]

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -1,3 +1,4 @@
+import dataclasses
 from abc import abstractmethod, ABCMeta
 from collections import deque
 from collections.abc import KeysView, MutableMapping
@@ -7,11 +8,10 @@ from typing import Any, Deque, Iterator, Type, Optional, List
 from itemadapter.utils import (
     _get_pydantic_model_metadata,
     _is_attrs_class,
-    _is_dataclass,
     _is_pydantic_model,
 )
 
-from itemadapter._imports import attr, dataclasses, _scrapy_item_classes
+from itemadapter._imports import attr, _scrapy_item_classes
 
 
 __all__ = [
@@ -139,23 +139,19 @@ class AttrsAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
 class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
     def __init__(self, item: Any) -> None:
         super().__init__(item)
-        if dataclasses is None:
-            raise RuntimeError("dataclasses module is not available")
         # store a reference to the item's fields to avoid O(n) lookups and O(n^2) traversals
         self._fields_dict = {field.name: field for field in dataclasses.fields(self.item)}
 
     @classmethod
     def is_item(cls, item: Any) -> bool:
-        return _is_dataclass(item) and not isinstance(item, type)
+        return dataclasses.is_dataclass(item) and not isinstance(item, type)
 
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
-        return _is_dataclass(item_class)
+        return dataclasses.is_dataclass(item_class)
 
     @classmethod
     def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:
-        if dataclasses is None:
-            raise RuntimeError("dataclasses module is not available")
         for field in dataclasses.fields(item_class):
             if field.name == field_name:
                 return field.metadata  # type: ignore
@@ -163,8 +159,6 @@ class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
 
     @classmethod
     def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
-        if dataclasses is None:
-            raise RuntimeError("dataclasses module is not available")
         return [a.name for a in dataclasses.fields(item_class)]
 
 

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -3,17 +3,10 @@ import warnings
 from types import MappingProxyType
 from typing import Any
 
-from itemadapter._imports import attr, dataclasses, pydantic
+from itemadapter._imports import attr, pydantic
 
 
 __all__ = ["is_item", "get_field_meta_from_class"]
-
-
-def _is_dataclass(obj: Any) -> bool:
-    """In py36, this returns False if the "dataclasses" backport module is not installed."""
-    if dataclasses is None:
-        return False
-    return dataclasses.is_dataclass(obj)
 
 
 def _is_attrs_class(obj: Any) -> bool:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import Callable, Generator, Optional
 
 from itemadapter import ItemAdapter
@@ -26,6 +27,39 @@ def clear_itemadapter_imports() -> Generator[None, None, None]:
         yield
     finally:
         sys.modules.update(backup)
+
+
+@dataclass
+class DataClassItem:
+    name: str = field(default_factory=lambda: None, metadata={"serializer": str})
+    value: int = field(default_factory=lambda: None, metadata={"serializer": int})
+
+
+@dataclass
+class DataClassItemNested:
+    nested: DataClassItem
+    adapter: ItemAdapter
+    dict_: dict
+    list_: list
+    set_: set
+    tuple_: tuple
+    int_: int
+
+
+@dataclass(init=False)
+class DataClassWithoutInit:
+    name: str = field(metadata={"serializer": str})
+    value: int = field(metadata={"serializer": int})
+
+
+@dataclass
+class DataClassItemSubclassed(DataClassItem):
+    subclassed: bool = True
+
+
+@dataclass
+class DataClassItemEmpty:
+    pass
 
 
 try:
@@ -64,45 +98,6 @@ else:
 
     @attr.s
     class AttrsItemEmpty:
-        pass
-
-
-try:
-    from dataclasses import dataclass, field
-except ImportError:
-    DataClassItem = None
-    DataClassItemNested = None
-    DataClassWithoutInit = None
-    DataClassItemSubclassed = None
-    DataClassItemEmpty = None
-else:
-
-    @dataclass
-    class DataClassItem:
-        name: str = field(default_factory=lambda: None, metadata={"serializer": str})
-        value: int = field(default_factory=lambda: None, metadata={"serializer": int})
-
-    @dataclass
-    class DataClassItemNested:
-        nested: DataClassItem
-        adapter: ItemAdapter
-        dict_: dict
-        list_: list
-        set_: set
-        tuple_: tuple
-        int_: int
-
-    @dataclass(init=False)
-    class DataClassWithoutInit:
-        name: str = field(metadata={"serializer": str})
-        value: int = field(metadata={"serializer": int})
-
-    @dataclass
-    class DataClassItemSubclassed(DataClassItem):
-        subclassed: bool = True
-
-    @dataclass
-    class DataClassItemEmpty:
         pass
 
 

--- a/tests/test_adapter_dataclasses.py
+++ b/tests/test_adapter_dataclasses.py
@@ -1,7 +1,6 @@
-import unittest
 import warnings
 from types import MappingProxyType
-from unittest import mock
+from unittest import mock, TestCase
 
 from itemadapter.utils import get_field_meta_from_class
 
@@ -16,7 +15,7 @@ from tests import (
 )
 
 
-class DataclassTestCase(unittest.TestCase):
+class DataclassTestCase(TestCase):
     def test_false(self):
         from itemadapter.adapter import DataclassAdapter
 
@@ -36,7 +35,6 @@ class DataclassTestCase(unittest.TestCase):
         self.assertFalse(DataclassAdapter.is_item({"a", "set"}))
         self.assertFalse(DataclassAdapter.is_item(DataClassItem))
 
-    @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
     @mock.patch("builtins.__import__", make_mock_import("dataclasses"))
     def test_module_import_error(self):
         with clear_itemadapter_imports():
@@ -53,7 +51,6 @@ class DataclassTestCase(unittest.TestCase):
             with self.assertRaises(TypeError, msg="DataClassItem is not a valid item class"):
                 get_field_meta_from_class(DataClassItem, "name")
 
-    @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
     @mock.patch("itemadapter.utils.dataclasses", None)
     def test_module_not_available(self):
         from itemadapter.adapter import DataclassAdapter
@@ -62,7 +59,6 @@ class DataclassTestCase(unittest.TestCase):
         with self.assertRaises(TypeError, msg="DataClassItem is not a valid item class"):
             get_field_meta_from_class(DataClassItem, "name")
 
-    @unittest.skipIf(not DataClassItem, "dataclasses module is not available")
     def test_true(self):
         from itemadapter.adapter import DataclassAdapter
 

--- a/tests/test_adapter_dataclasses.py
+++ b/tests/test_adapter_dataclasses.py
@@ -1,6 +1,6 @@
 import warnings
 from types import MappingProxyType
-from unittest import mock, TestCase
+from unittest import TestCase
 
 from itemadapter.utils import get_field_meta_from_class
 
@@ -10,8 +10,6 @@ from tests import (
     PydanticModel,
     ScrapyItem,
     ScrapySubclassedItem,
-    make_mock_import,
-    clear_itemadapter_imports,
 )
 
 
@@ -34,30 +32,6 @@ class DataclassTestCase(TestCase):
         self.assertFalse(DataclassAdapter.is_item(("a", "tuple")))
         self.assertFalse(DataclassAdapter.is_item({"a", "set"}))
         self.assertFalse(DataclassAdapter.is_item(DataClassItem))
-
-    @mock.patch("builtins.__import__", make_mock_import("dataclasses"))
-    def test_module_import_error(self):
-        with clear_itemadapter_imports():
-            from itemadapter.adapter import DataclassAdapter
-
-            self.assertFalse(DataclassAdapter.is_item(DataClassItem(name="asdf", value=1234)))
-            with self.assertRaises(RuntimeError, msg="dataclasses module is not available"):
-                DataclassAdapter(DataClassItem(name="asdf", value=1234))
-            with self.assertRaises(RuntimeError, msg="dataclasses module is not available"):
-                DataclassAdapter.get_field_meta_from_class(DataClassItem, "name")
-            with self.assertRaises(RuntimeError, msg="dataclasses module is not available"):
-                DataclassAdapter.get_field_names_from_class(DataClassItem)
-
-            with self.assertRaises(TypeError, msg="DataClassItem is not a valid item class"):
-                get_field_meta_from_class(DataClassItem, "name")
-
-    @mock.patch("itemadapter.utils.dataclasses", None)
-    def test_module_not_available(self):
-        from itemadapter.adapter import DataclassAdapter
-
-        self.assertFalse(DataclassAdapter.is_item(DataClassItem(name="asdf", value=1234)))
-        with self.assertRaises(TypeError, msg="DataClassItem is not a valid item class"):
-            get_field_meta_from_class(DataClassItem, "name")
 
     def test_true(self):
         from itemadapter.adapter import DataclassAdapter


### PR DESCRIPTION
Follow up of #66: no need to catch import errors when importing things from `dataclasses`.