### PR TITLE
Test with pydantic<2, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently supported types are:
 * [`dict`](https://docs.python.org/3/library/stdtypes.html#dict)
 * [`dataclass`](https://docs.python.org/3/library/dataclasses.html)-based classes
 * [`attrs`](https://www.attrs.org)-based classes
-* [`pydantic`](https://pydantic-docs.helpmanual.io/)-based classes
+* [`pydantic`](https://pydantic-docs.helpmanual.io/)-based classes (`pydantic>=2` not yet supported)
 
 Additionally, interaction with arbitrary types is supported, by implementing
 a pre-defined interface (see [extending `itemadapter`](#extending-itemadapter)).
@@ -27,7 +27,8 @@ a pre-defined interface (see [extending `itemadapter`](#extending-itemadapter)).
 * Python 3.7+
 * [`scrapy`](https://scrapy.org/): optional, needed to interact with `scrapy` items
 * [`attrs`](https://pypi.org/project/attrs/): optional, needed to interact with `attrs`-based items
-* [`pydantic`](https://pypi.org/project/pydantic/): optional, needed to interact with `pydantic`-based items
+* [`pydantic`](https://pypi.org/project/pydantic/): optional, needed to interact with
+  `pydantic`-based items (`pydantic>=2` not yet supported)
 
 ---
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 attrs
-pydantic
+pydantic<2
 pytest-cov>=2.8
 pytest>=5.4
 scrapy>=2.0

--- a/tests/test_adapter_pydantic.py
+++ b/tests/test_adapter_pydantic.py
@@ -17,7 +17,7 @@ from tests import (
 )
 
 
-class DataclassTestCase(unittest.TestCase):
+class PydanticTestCase(unittest.TestCase):
     def test_false(self):
         from itemadapter.adapter import PydanticAdapter
 


### PR DESCRIPTION
By no means a fix for #72, let's just clarify the supported versions in the readme and make sure tests run with them.