### PR TITLE
Add pydantic v2 support with backwards compatibility

### DIFF
--- a/itemadapter/_imports.py
+++ b/itemadapter/_imports.py
@@ -23,6 +23,12 @@ except ImportError:
     attr = None  # type: ignore [assignment]
 
 try:
+    import pydantic.v1 as pydantic_v1  # pylint: disable=W0611 (unused-import)
     import pydantic  # pylint: disable=W0611 (unused-import)
 except ImportError:
-    pydantic = None  # type: ignore [assignment]
+    try:
+        import pydantic as pydantic_v1  # pylint: disable=W0611 (unused-import)
+        pydantic = None  # type: ignore [assignment]
+    except ImportError:
+        # Handle the case where neither pydantic.v1 nor pydantic is available
+        pydantic_v1 = None

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -2,7 +2,7 @@ import warnings
 from types import MappingProxyType
 from typing import Any
 
-from itemadapter._imports import attr, pydantic
+from itemadapter._imports import attr, pydantic, pydantic_v1
 
 __all__ = ["is_item", "get_field_meta_from_class"]
 
@@ -19,7 +19,62 @@ def _is_pydantic_model(obj: Any) -> bool:
     return issubclass(obj, pydantic.BaseModel)
 
 
+def _is_pydantic_v1_model(obj: Any) -> bool:
+    if pydantic_v1 is None:
+        return False
+    return issubclass(obj, pydantic_v1.BaseModel)
+
+
 def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
+    metadata = {}
+    field = item_model.model_fields[field_name]
+
+    for attribute in [
+        "default",
+        "default_factory",
+        "alias",
+        "alias_priority",
+        "validation_alias",
+        "serialization_alias",
+        "title",
+        "field_title_generator",
+        "description",
+        "examples",
+        "exclude",
+        "discriminator",
+        "deprecated",
+        "json_schema_extra",
+        "frozen",
+        "validate_default",
+        "repr",
+        "init",
+        "init_var",
+        "kw_only",
+        "pattern",
+        "strict",
+        "coerce_numbers_to_str",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "multiple_of",
+        "allow_inf_nan",
+        "max_digits",
+        "decimal_places",
+        "min_length",
+        "max_length",
+        "union_mode",
+        "fail_fast",
+    ]:
+        if hasattr(field, attribute) and (value := getattr(field, attribute)) is not None:
+            metadata[attribute] = value
+        # if field.json_schema_extra is not None:
+        #     metadata.update(field.json_schema_extra)
+
+    return MappingProxyType(metadata)
+
+
+def _get_pydantic_v1_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
     metadata = {}
     field = item_model.__fields__[field_name].field_info
 


### PR DESCRIPTION
Here I tried to add support for pydantic v2 BaseModel and Field.

This solution theoretically (we cover with tests once maintainers approve this implementation) work with any pydantic package.
I tested it with real project and these packages seems to be working with simple Item model.
`pydantic<1.10` - Before new `BaseModel`
`pydantic>=1.10.17` - In the migration guide they mention this exact version where they moved old `BaseModel` under `pydantic.v1` [namespace](https://docs.pydantic.dev/2.8/migration/#continue-using-pydantic-v1-features) 

Similarly I tried to move `v1` specific adapter and model under `pydantic_v1` and used `pydantic` for new version.
I also tried to include all `Field` attributes to metadata and of course if some of them don't work fine we can remove or workaround. 
If this implementation is acceptable I will try to add some tests and docs. Let me know what we can adjust.

Fixes #72