### PR TITLE
Pydantic v2 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,13 +11,16 @@ jobs:
         include:
         - python-version: 3.13
           env:
-            TOXENV: pylint
-        - python-version: 3.13
-          env:
             TOXENV: typing
         - python-version: 3.13
           env:
+            TOXENV: docs
+        - python-version: 3.13
+          env:
             TOXENV: twinecheck
+        - python-version: 3.13
+          env:
+            TOXENV: pylint
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@ jobs:
             TOXENV: min-scrapy
         - python-version: "3.9"
           env:
+            TOXENV: min-extra
+        - python-version: "3.9"
+          env:
             TOXENV: py
         - python-version: "3.10"
           env:
@@ -49,6 +52,12 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: scrapy
+        - python-version: "3.13"
+          env:
+            TOXENV: extra
+        - python-version: "3.13"
+          env:
+            TOXENV: extra-pydantic1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,15 @@ jobs:
         include:
         - python-version: "3.9"
           env:
+            TOXENV: min-attrs
+        - python-version: "3.9"
+          env:
+            TOXENV: min-pydantic
+        - python-version: "3.9"
+          env:
+            TOXENV: min-scrapy
+        - python-version: "3.9"
+          env:
             TOXENV: py
         - python-version: "3.10"
           env:
@@ -28,14 +37,18 @@ jobs:
         - python-version: "3.13"
           env:
             TOXENV: py
-
-        # pinned deps
-        - python-version: "3.9"
+        - python-version: "3.13"
           env:
-            TOXENV: py39-scrapy22
-        - python-version: "3.9"
+            TOXENV: attrs
+        - python-version: "3.13"
           env:
-            TOXENV: py-pydantic1
+            TOXENV: pydantic1
+        - python-version: "3.13"
+          env:
+            TOXENV: pydantic
+        - python-version: "3.13"
+          env:
+            TOXENV: scrapy
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,7 @@ jobs:
       run: pip install tox
 
     - name: Run tests
+      env: ${{ matrix.env }}
       run: tox
 
     - name: Upload coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .coverage
 htmlcov/
 coverage.xml
+/dist/

--- a/README.md
+++ b/README.md
@@ -156,8 +156,7 @@ The following adapters are included by default:
 * `itemadapter.adapter.DictAdapter`: handles `Python` dictionaries
 * `itemadapter.adapter.DataclassAdapter`: handles `dataclass` objects
 * `itemadapter.adapter.AttrsAdapter`: handles `attrs` objects
-* `itemadapter.adapter.PydanticV1Adapter`: handles `pydantic` 1.x objects
-* `itemadapter.adapter.PydanticAdapter`: handles `pydantic` 2+ objects
+* `itemadapter.adapter.PydanticAdapter`: handles `pydantic` objects
 
 ### class `itemadapter.adapter.ItemAdapter(item: Any)`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently supported types are:
 * [`dict`](https://docs.python.org/3/library/stdtypes.html#dict)
 * [`dataclass`](https://docs.python.org/3/library/dataclasses.html)-based classes
 * [`attrs`](https://www.attrs.org)-based classes
-* [`pydantic`](https://pydantic-docs.helpmanual.io/)-based classes (`pydantic>=2` not yet supported)
+* [`pydantic`](https://pydantic-docs.helpmanual.io/)-based classes
 
 Additionally, interaction with arbitrary types is supported, by implementing
 a pre-defined interface (see [extending `itemadapter`](#extending-itemadapter)).
@@ -24,11 +24,14 @@ a pre-defined interface (see [extending `itemadapter`](#extending-itemadapter)).
 
 ## Requirements
 
-* Python 3.9+, either the CPython implementation (default) or the PyPy implementation
-* [`scrapy`](https://scrapy.org/): optional, needed to interact with `scrapy` items
-* [`attrs`](https://pypi.org/project/attrs/): optional, needed to interact with `attrs`-based items
-* [`pydantic`](https://pypi.org/project/pydantic/): optional, needed to interact with
-  `pydantic`-based items (`pydantic>=2` not yet supported)
+* Python 3.9+, either the CPython implementation (default) or the PyPy
+  implementation
+* [`scrapy`](https://scrapy.org/) 2.2+: optional, needed to interact with
+  `scrapy` items
+* [`attrs`](https://pypi.org/project/attrs/) 18.1.0+: optional, needed to
+  interact with `attrs`-based items
+* [`pydantic`](https://pypi.org/project/pydantic/) 1.8+: optional, needed to
+  interact with `pydantic`-based items
 
 ---
 
@@ -38,6 +41,20 @@ a pre-defined interface (see [extending `itemadapter`](#extending-itemadapter)).
 
 ```
 pip install itemadapter
+```
+
+For `attrs`, `pydantic` and `scrapy` support, install the corresponding extra
+to ensure that a supported version of the corresponding dependencies is
+installed. For example:
+
+```
+pip install itemadapter[scrapy]
+```
+
+Mind that you can install multiple extras as needed. For example:
+
+```
+pip install itemadapter[attrs,pydantic,scrapy]
 ```
 
 ---
@@ -139,7 +156,8 @@ The following adapters are included by default:
 * `itemadapter.adapter.DictAdapter`: handles `Python` dictionaries
 * `itemadapter.adapter.DataclassAdapter`: handles `dataclass` objects
 * `itemadapter.adapter.AttrsAdapter`: handles `attrs` objects
-* `itemadapter.adapter.PydanticAdapter`: handles `pydantic` objects
+* `itemadapter.adapter.PydanticV1Adapter`: handles `pydantic` 1.x objects
+* `itemadapter.adapter.PydanticAdapter`: handles `pydantic` 2+ objects
 
 ### class `itemadapter.adapter.ItemAdapter(item: Any)`
 
@@ -306,9 +324,9 @@ mappingproxy({'serializer': <class 'int'>, 'limit': 100})
 ...
 >>> adapter = ItemAdapter(InventoryItem(name="foo", value=10))
 >>> adapter.get_field_meta("name")
-mappingproxy({'serializer': <class 'str'>})
+mappingproxy({'default': PydanticUndefined, 'json_schema_extra': {'serializer': <class 'str'>}, 'repr': True})
 >>> adapter.get_field_meta("value")
-mappingproxy({'serializer': <class 'int'>, 'limit': 100})
+mappingproxy({'default': PydanticUndefined, 'json_schema_extra': {'serializer': <class 'int'>, 'limit': 100}, 'repr': True})
 >>>
 ```
 
@@ -361,19 +379,23 @@ so all methods from the `MutableMapping` interface must be implemented as well.
 
 ### Registering an adapter
 
-Add your custom adapter class to the `itemadapter.adapter.ItemAdapter.ADAPTER_CLASSES`
-class attribute in order to handle custom item classes:
+Add your custom adapter class to the
+`itemadapter.adapter.ItemAdapter.ADAPTER_CLASSES` class attribute in order to
+handle custom item classes.
 
 **Example**
+```
+pip install zyte-common-items
+```
 ```python
 >>> from itemadapter.adapter import ItemAdapter
->>> from tests.test_interface import BaseFakeItemAdapter, FakeItemClass
+>>> from zyte_common_items import Item, ZyteItemAdapter
 >>>
->>> ItemAdapter.ADAPTER_CLASSES.appendleft(BaseFakeItemAdapter)
->>> item = FakeItemClass()
+>>> ItemAdapter.ADAPTER_CLASSES.appendleft(ZyteItemAdapter)
+>>> item = Item()
 >>> adapter = ItemAdapter(item)
 >>> adapter
-<ItemAdapter for FakeItemClass()>
+<ItemAdapter for Item()>
 >>>
 ```
 

--- a/itemadapter/_imports.py
+++ b/itemadapter/_imports.py
@@ -23,6 +23,12 @@ except ImportError:
     attr = None  # type: ignore [assignment]
 
 try:
+    import pydantic.v1 as pydantic_v1  # pylint: disable=W0611 (unused-import)
     import pydantic  # pylint: disable=W0611 (unused-import)
 except ImportError:
-    pydantic = None  # type: ignore [assignment]
+    try:
+        import pydantic as pydantic_v1  # pylint: disable=W0611 (unused-import)
+        pydantic = None  # type: ignore [assignment]
+    except ImportError:
+        # Handle the case where neither pydantic.v1 nor pydantic is available
+        pydantic_v1 = None

--- a/itemadapter/_imports.py
+++ b/itemadapter/_imports.py
@@ -1,38 +1,49 @@
 # attempt the following imports only once,
 # to be imported from itemadapter's submodules
 
+from typing import Any
+
 _scrapy_item_classes: tuple
+scrapy: Any
 
 try:
     import scrapy  # pylint: disable=W0611 (unused-import)
 except ImportError:
-    scrapy = None  # type: ignore[assignment]
     _scrapy_item_classes = ()
+    scrapy = None
 else:
     try:
         # handle deprecated base classes
         _base_item_cls = getattr(
             scrapy.item,
             "_BaseItem",
-            scrapy.item.BaseItem,  # type: ignore[attr-defined]
+            scrapy.item.BaseItem,
         )
     except AttributeError:
         _scrapy_item_classes = (scrapy.item.Item,)
     else:
         _scrapy_item_classes = (scrapy.item.Item, _base_item_cls)
 
+attr: Any
 try:
     import attr  # pylint: disable=W0611 (unused-import)
 except ImportError:
-    attr = None  # type: ignore[assignment]
+    attr = None
+
+pydantic_v1: Any = None
+pydantic: Any = None
 
 try:
-    import pydantic.v1 as pydantic_v1  # pylint: disable=W0611 (unused-import)
     import pydantic  # pylint: disable=W0611 (unused-import)
-except ImportError:
+except ImportError:  # No pydantic
+    pass
+else:
     try:
-        import pydantic as pydantic_v1  # pylint: disable=W0611 (unused-import)
-        pydantic = None  # type: ignore[assignment]
-    except ImportError:
-        # Handle the case where neither pydantic.v1 nor pydantic is available
-        pydantic_v1 = None
+        import pydantic.v1 as pydantic_v1  # pylint: disable=W0611 (unused-import)
+    except ImportError:  # Pydantic <1.10.17
+        pydantic_v1 = pydantic
+        pydantic = None  # pylint: disable=C0103 (invalid-name)
+    else:  # Pydantic 1.10.17+
+        if not hasattr(pydantic.BaseModel, "model_fields"):  # Pydantic <2
+            pydantic_v1 = pydantic
+            pydantic = None  # pylint: disable=C0103 (invalid-name)

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -11,7 +11,7 @@ from itemadapter.utils import (
     _get_pydantic_v1_model_metadata,
     _is_attrs_class,
     _is_pydantic_model,
-    _is_pydantic_v1_model
+    _is_pydantic_v1_model,
 )
 
 __all__ = [
@@ -218,7 +218,6 @@ class PydanticV1Adapter(AdapterInterface):
 
 class PydanticAdapter(AdapterInterface):
     item: Any
-    import pydantic
 
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
@@ -232,7 +231,7 @@ class PydanticAdapter(AdapterInterface):
             raise KeyError(f"{item_class.__name__} does not support field: {field_name}")
 
     @classmethod
-    def get_field_names_from_class(cls, item_class: pydantic.BaseModel) -> Optional[List[str]]:
+    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
         return list(item_class.model_fields.keys())  # type: ignore[attr-defined]
 
     def field_names(self) -> KeysView:
@@ -334,7 +333,7 @@ class ItemAdapter(MutableMapping):
             DataclassAdapter,
             AttrsAdapter,
             PydanticV1Adapter,
-            PydanticAdapter
+            PydanticAdapter,
         ]
     )
 

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -227,8 +227,7 @@ class PydanticAdapter(AdapterInterface):
                     if hasattr(self.item, field_name):
                         delattr(self.item, field_name)
                         return
-                    else:
-                        raise AttributeError
+                    raise AttributeError
                 except AttributeError:
                     raise KeyError(field_name)
         else:
@@ -237,8 +236,7 @@ class PydanticAdapter(AdapterInterface):
                     if hasattr(self.item, field_name):
                         delattr(self.item, field_name)
                         return
-                    else:
-                        raise AttributeError
+                    raise AttributeError
                 except AttributeError:
                     raise KeyError(field_name)
         raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -20,7 +20,6 @@ __all__ = [
     "DataclassAdapter",
     "DictAdapter",
     "ItemAdapter",
-    "PydanticV1Adapter",
     "PydanticAdapter",
     "ScrapyItemAdapter",
 ]
@@ -165,103 +164,90 @@ class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
         return [a.name for a in dataclasses.fields(item_class)]
 
 
-class PydanticV1Adapter(AdapterInterface):
-    item: Any
-
-    @classmethod
-    def is_item_class(cls, item_class: type) -> bool:
-        return _is_pydantic_v1_model(item_class)
-
-    @classmethod
-    def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:
-        try:
-            return _get_pydantic_v1_model_metadata(item_class, field_name)
-        except KeyError:
-            raise KeyError(f"{item_class.__name__} does not support field: {field_name}")
-
-    @classmethod
-    def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
-        return list(item_class.__fields__.keys())  # type: ignore[attr-defined]
-
-    def field_names(self) -> KeysView:
-        return KeysView(self.item.__fields__)
-
-    def __getitem__(self, field_name: str) -> Any:
-        if field_name in self.item.__fields__:
-            return getattr(self.item, field_name)
-        raise KeyError(field_name)
-
-    def __setitem__(self, field_name: str, value: Any) -> None:
-        if field_name in self.item.__fields__:
-            setattr(self.item, field_name, value)
-        else:
-            raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
-
-    def __delitem__(self, field_name: str) -> None:
-        if field_name in self.item.__fields__:
-            try:
-                if hasattr(self.item, field_name):
-                    delattr(self.item, field_name)
-                else:
-                    raise AttributeError
-            except AttributeError:
-                raise KeyError(field_name)
-        else:
-            raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
-
-    def __iter__(self) -> Iterator:
-        return iter(attr for attr in self.item.__fields__ if hasattr(self.item, attr))
-
-    def __len__(self) -> int:
-        return len(list(iter(self)))
-
-
 class PydanticAdapter(AdapterInterface):
     item: Any
 
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
-        return _is_pydantic_model(item_class)
+        return _is_pydantic_model(item_class) or _is_pydantic_v1_model(item_class)
 
     @classmethod
     def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:
         try:
-            return _get_pydantic_model_metadata(item_class, field_name)
+            try:
+                return _get_pydantic_model_metadata(item_class, field_name)
+            except AttributeError:
+                return _get_pydantic_v1_model_metadata(item_class, field_name)
         except KeyError:
             raise KeyError(f"{item_class.__name__} does not support field: {field_name}")
 
     @classmethod
     def get_field_names_from_class(cls, item_class: type) -> Optional[List[str]]:
-        return list(item_class.model_fields.keys())  # type: ignore[attr-defined]
+        try:
+            return list(item_class.model_fields.keys())  # type: ignore[attr-defined]
+        except AttributeError:
+            return list(item_class.__fields__.keys())  # type: ignore[attr-defined]
 
     def field_names(self) -> KeysView:
-        return KeysView(self.item.model_fields)
+        try:
+            return KeysView(self.item.model_fields)
+        except AttributeError:
+            return KeysView(self.item.__fields__)
 
     def __getitem__(self, field_name: str) -> Any:
-        if field_name in self.item.model_fields:
-            return getattr(self.item, field_name)
+        try:
+            self.item.model_fields
+        except AttributeError:
+            if field_name in self.item.__fields__:
+                return getattr(self.item, field_name)
+        else:
+            if field_name in self.item.model_fields:
+                return getattr(self.item, field_name)
         raise KeyError(field_name)
 
     def __setitem__(self, field_name: str, value: Any) -> None:
-        if field_name in self.item.model_fields:
-            setattr(self.item, field_name, value)
+        try:
+            self.item.model_fields
+        except AttributeError:
+            if field_name in self.item.__fields__:
+                setattr(self.item, field_name, value)
+                return
         else:
-            raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
+            if field_name in self.item.model_fields:
+                setattr(self.item, field_name, value)
+                return
+        raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
 
     def __delitem__(self, field_name: str) -> None:
-        if field_name in self.item.model_fields:
-            try:
-                if hasattr(self.item, field_name):
-                    delattr(self.item, field_name)
-                else:
-                    raise AttributeError
-            except AttributeError:
-                raise KeyError(field_name)
+        try:
+            self.item.model_fields
+        except AttributeError:
+            if field_name in self.item.__fields__:
+                try:
+                    if hasattr(self.item, field_name):
+                        delattr(self.item, field_name)
+                        return
+                    else:
+                        raise AttributeError
+                except AttributeError:
+                    raise KeyError(field_name)
         else:
-            raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
+            if field_name in self.item.model_fields:
+                try:
+                    if hasattr(self.item, field_name):
+                        delattr(self.item, field_name)
+                        return
+                    else:
+                        raise AttributeError
+                except AttributeError:
+                    raise KeyError(field_name)
+        raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
 
     def __iter__(self) -> Iterator:
-        return iter(attr for attr in self.item.model_fields if hasattr(self.item, attr))
+        try:
+            return iter(attr for attr in self.item.model_fields if hasattr(self.item, attr))
+        except AttributeError:
+            return iter(attr for attr in self.item.__fields__ if hasattr(self.item, attr))
 
     def __len__(self) -> int:
         return len(list(iter(self)))
@@ -332,7 +318,6 @@ class ItemAdapter(MutableMapping):
             DictAdapter,
             DataclassAdapter,
             AttrsAdapter,
-            PydanticV1Adapter,
             PydanticAdapter,
         ]
     )

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -2,7 +2,7 @@ import warnings
 from types import MappingProxyType
 from typing import Any
 
-from itemadapter._imports import attr, pydantic
+from itemadapter._imports import attr, pydantic, pydantic_v1
 
 __all__ = ["is_item", "get_field_meta_from_class"]
 
@@ -19,7 +19,62 @@ def _is_pydantic_model(obj: Any) -> bool:
     return issubclass(obj, pydantic.BaseModel)
 
 
+def _is_pydantic_v1_model(obj: Any) -> bool:
+    if pydantic_v1 is None:
+        return False
+    return issubclass(obj, pydantic_v1.BaseModel)
+
+
 def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
+    metadata = {}
+    field = item_model.model_fields[field_name]
+
+    for attribute in [
+        "default",
+        "default_factory",
+        "alias",
+        "alias_priority",
+        "validation_alias",
+        "serialization_alias",
+        "title",
+        "field_title_generator",
+        "description",
+        "examples",
+        "exclude",
+        "discriminator",
+        "deprecated",
+        "json_schema_extra",
+        "frozen",
+        "validate_default",
+        "repr",
+        "init",
+        "init_var",
+        "kw_only",
+        "pattern",
+        "strict",
+        "coerce_numbers_to_str",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "multiple_of",
+        "allow_inf_nan",
+        "max_digits",
+        "decimal_places",
+        "min_length",
+        "max_length",
+        "union_mode",
+        "fail_fast",
+    ]:
+        if hasattr(field, attribute) and (value := getattr(field, attribute)) is not None:
+            metadata[attribute] = value
+        # if field.json_schema_extra is not None:
+        #     metadata.update(field.json_schema_extra)
+
+    return MappingProxyType(metadata)
+
+
+def _get_pydantic_v1_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
     metadata = {}
     field = item_model.__fields__[field_name].field_info
 

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -68,8 +68,6 @@ def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingPro
     ]:
         if hasattr(field, attribute) and (value := getattr(field, attribute)) is not None:
             metadata[attribute] = value
-        # if field.json_schema_extra is not None:
-        #     metadata.update(field.json_schema_extra)
 
     return MappingProxyType(metadata)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 filterwarnings =
-    ignore:.*BaseItem.*:scrapy.exceptions.ScrapyDeprecationWarning
+    ignore:.*BaseItem.*

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ setuptools.setup(
     },
     include_package_data=True,
     python_requires=">=3.9",
+    extras_require={
+        "attrs": ["attrs>=18.1.0"],
+        "pydantic": ["pydantic>=1.8"],
+        "scrapy": ["scrapy>=2.2"],
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: BSD License",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Generator, Optional
 
 from itemadapter import ItemAdapter
+from itemadapter._imports import pydantic, pydantic_v1
 
 
 def make_mock_import(block_name: str) -> Callable:
@@ -101,29 +102,26 @@ else:
         pass
 
 
-try:
-    from pydantic import BaseModel
-    from pydantic import Field as PydanticField
-except ImportError:
-    PydanticModel = None
-    PydanticSpecialCasesModel = None
-    PydanticModelNested = None
-    PydanticModelSubclassed = None
-    PydanticModelEmpty = None
+if pydantic_v1 is None:
+    PydanticV1Model = None
+    PydanticV1SpecialCasesModel = None
+    PydanticV1ModelNested = None
+    PydanticV1ModelSubclassed = None
+    PydanticV1ModelEmpty = None
 else:
 
-    class PydanticModel(BaseModel):
-        name: Optional[str] = PydanticField(
+    class PydanticV1Model(pydantic_v1.BaseModel):
+        name: Optional[str] = pydantic_v1.Field(
             default_factory=lambda: None,
             serializer=str,
         )
-        value: Optional[int] = PydanticField(
+        value: Optional[int] = pydantic_v1.Field(
             default_factory=lambda: None,
             serializer=int,
         )
 
-    class PydanticSpecialCasesModel(BaseModel):
-        special_cases: Optional[int] = PydanticField(
+    class PydanticV1SpecialCasesModel(pydantic_v1.BaseModel):
+        special_cases: Optional[int] = pydantic_v1.Field(
             default_factory=lambda: None,
             alias="special_cases",
             allow_mutation=False,
@@ -132,7 +130,56 @@ else:
         class Config:
             validate_assignment = True
 
-    class PydanticModelNested(BaseModel):
+    class PydanticV1ModelNested(pydantic_v1.BaseModel):
+        nested: PydanticV1Model
+        adapter: ItemAdapter
+        dict_: dict
+        list_: list
+        set_: set
+        tuple_: tuple
+        int_: int
+
+        class Config:
+            arbitrary_types_allowed = True
+
+    class PydanticV1ModelSubclassed(PydanticV1Model):
+        subclassed: bool = pydantic_v1.Field(
+            default_factory=lambda: True,
+        )
+
+    class PydanticV1ModelEmpty(pydantic_v1.BaseModel):
+        pass
+
+
+if pydantic is None:
+    PydanticModel = None
+    PydanticSpecialCasesModel = None
+    PydanticModelNested = None
+    PydanticModelSubclassed = None
+    PydanticModelEmpty = None
+else:
+
+    class PydanticModel(pydantic.BaseModel):
+        name: Optional[str] = pydantic.Field(
+            default_factory=lambda: None,
+            serializer=str,
+        )
+        value: Optional[int] = pydantic.Field(
+            default_factory=lambda: None,
+            serializer=int,
+        )
+
+    class PydanticSpecialCasesModel(pydantic.BaseModel):
+        special_cases: Optional[int] = pydantic.Field(
+            default_factory=lambda: None,
+            alias="special_cases",
+            allow_mutation=False,
+        )
+
+        class Config:
+            validate_assignment = True
+
+    class PydanticModelNested(pydantic.BaseModel):
         nested: PydanticModel
         adapter: ItemAdapter
         dict_: dict
@@ -145,11 +192,11 @@ else:
             arbitrary_types_allowed = True
 
     class PydanticModelSubclassed(PydanticModel):
-        subclassed: bool = PydanticField(
+        subclassed: bool = pydantic.Field(
             default_factory=lambda: True,
         )
 
-    class PydanticModelEmpty(BaseModel):
+    class PydanticModelEmpty(pydantic.BaseModel):
         pass
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,3 @@
-attrs
-pydantic
-pytest-cov>=2.8
 pytest>=5.4
-scrapy>=2.0
+pytest-cov>=2.8
+

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -14,10 +14,10 @@ from tests import (
     DataClassItemNested,
     DataClassItemSubclassed,
     DataClassWithoutInit,
-    PydanticModel,
-    PydanticModelEmpty,
-    PydanticModelNested,
-    PydanticModelSubclassed,
+    PydanticV1Model,
+    PydanticV1ModelEmpty,
+    PydanticV1ModelNested,
+    PydanticV1ModelSubclassed,
     ScrapySubclassedItem,
     ScrapySubclassedItemEmpty,
     ScrapySubclassedItemNested,
@@ -77,13 +77,13 @@ class ItemAdapterReprTestCase(unittest.TestCase):
             repr(adapter), "<ItemAdapter for AttrsItemWithoutInit(name='set after init')>"
         )
 
-    @unittest.skipIf(not PydanticModel, "pydantic module is not available")
+    @unittest.skipIf(not PydanticV1Model, "pydantic module is not available")
     def test_repr_pydantic(self):
-        item = PydanticModel(name="asdf", value=1234)
+        item = PydanticV1Model(name="asdf", value=1234)
         adapter = ItemAdapter(item)
         self.assertEqual(
             repr(adapter),
-            "<ItemAdapter for PydanticModel(name='asdf', value=1234)>",
+            "<ItemAdapter for PydanticV1Model(name='asdf', value=1234)>",
         )
 
 
@@ -264,11 +264,11 @@ class ScrapySubclassedItemTestCase(NonDictTestMixin, unittest.TestCase):
             adapter["name"]
 
 
-class PydanticModelTestCase(NonDictTestMixin, unittest.TestCase):
-    item_class = PydanticModel
-    item_class_nested = PydanticModelNested
-    item_class_subclassed = PydanticModelSubclassed
-    item_class_empty = PydanticModelEmpty
+class PydanticV1ModelTestCase(NonDictTestMixin, unittest.TestCase):
+    item_class = PydanticV1Model
+    item_class_nested = PydanticV1ModelNested
+    item_class_subclassed = PydanticV1ModelSubclassed
+    item_class_empty = PydanticV1ModelEmpty
 
 
 class DataClassItemTestCase(NonDictTestMixin, unittest.TestCase):

--- a/tests/test_adapter_attrs.py
+++ b/tests/test_adapter_attrs.py
@@ -7,6 +7,7 @@ from itemadapter.utils import get_field_meta_from_class
 from tests import (
     AttrsItem,
     DataClassItem,
+    PydanticModel,
     PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
@@ -32,9 +33,9 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(AttrsAdapter.is_item({"a", "set"}))
         self.assertFalse(AttrsAdapter.is_item(AttrsItem))
 
-        from itemadapter._imports import pydantic_v1
-
-        if pydantic_v1 is not None:
+        if PydanticModel is not None:
+            self.assertFalse(AttrsAdapter.is_item(PydanticModel()))
+        if PydanticV1Model is not None:
             self.assertFalse(AttrsAdapter.is_item(PydanticV1Model()))
 
         try:

--- a/tests/test_adapter_attrs.py
+++ b/tests/test_adapter_attrs.py
@@ -7,7 +7,7 @@ from itemadapter.utils import get_field_meta_from_class
 from tests import (
     AttrsItem,
     DataClassItem,
-    PydanticModel,
+    PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
     clear_itemadapter_imports,
@@ -23,10 +23,7 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(AttrsAdapter.is_item(sum))
         self.assertFalse(AttrsAdapter.is_item(1234))
         self.assertFalse(AttrsAdapter.is_item(object()))
-        self.assertFalse(AttrsAdapter.is_item(ScrapyItem()))
         self.assertFalse(AttrsAdapter.is_item(DataClassItem()))
-        self.assertFalse(AttrsAdapter.is_item(PydanticModel()))
-        self.assertFalse(AttrsAdapter.is_item(ScrapySubclassedItem()))
         self.assertFalse(AttrsAdapter.is_item("a string"))
         self.assertFalse(AttrsAdapter.is_item(b"some bytes"))
         self.assertFalse(AttrsAdapter.is_item({"a": "dict"}))
@@ -34,6 +31,19 @@ class AttrsTestCase(unittest.TestCase):
         self.assertFalse(AttrsAdapter.is_item(("a", "tuple")))
         self.assertFalse(AttrsAdapter.is_item({"a", "set"}))
         self.assertFalse(AttrsAdapter.is_item(AttrsItem))
+
+        from itemadapter._imports import pydantic_v1
+
+        if pydantic_v1 is not None:
+            self.assertFalse(AttrsAdapter.is_item(PydanticV1Model()))
+
+        try:
+            import scrapy  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(AttrsAdapter.is_item(ScrapyItem()))
+            self.assertFalse(AttrsAdapter.is_item(ScrapySubclassedItem()))
 
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
     @mock.patch("builtins.__import__", make_mock_import("attr"))

--- a/tests/test_adapter_dataclasses.py
+++ b/tests/test_adapter_dataclasses.py
@@ -6,7 +6,7 @@ from itemadapter.utils import get_field_meta_from_class
 from tests import (
     AttrsItem,
     DataClassItem,
-    PydanticModel,
+    PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
 )
@@ -20,10 +20,6 @@ class DataclassTestCase(TestCase):
         self.assertFalse(DataclassAdapter.is_item(sum))
         self.assertFalse(DataclassAdapter.is_item(1234))
         self.assertFalse(DataclassAdapter.is_item(object()))
-        self.assertFalse(DataclassAdapter.is_item(ScrapyItem()))
-        self.assertFalse(DataclassAdapter.is_item(AttrsItem()))
-        self.assertFalse(DataclassAdapter.is_item(PydanticModel()))
-        self.assertFalse(DataclassAdapter.is_item(ScrapySubclassedItem()))
         self.assertFalse(DataclassAdapter.is_item("a string"))
         self.assertFalse(DataclassAdapter.is_item(b"some bytes"))
         self.assertFalse(DataclassAdapter.is_item({"a": "dict"}))
@@ -31,6 +27,26 @@ class DataclassTestCase(TestCase):
         self.assertFalse(DataclassAdapter.is_item(("a", "tuple")))
         self.assertFalse(DataclassAdapter.is_item({"a", "set"}))
         self.assertFalse(DataclassAdapter.is_item(DataClassItem))
+
+        try:
+            import attrs  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(DataclassAdapter.is_item(AttrsItem()))
+
+        from itemadapter._imports import pydantic_v1
+
+        if pydantic_v1 is not None:
+            self.assertFalse(DataclassAdapter.is_item(PydanticV1Model()))
+
+        try:
+            import scrapy  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(DataclassAdapter.is_item(ScrapyItem()))
+            self.assertFalse(DataclassAdapter.is_item(ScrapySubclassedItem()))
 
     def test_true(self):
         from itemadapter.adapter import DataclassAdapter

--- a/tests/test_adapter_dataclasses.py
+++ b/tests/test_adapter_dataclasses.py
@@ -6,6 +6,7 @@ from itemadapter.utils import get_field_meta_from_class
 from tests import (
     AttrsItem,
     DataClassItem,
+    PydanticModel,
     PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
@@ -35,9 +36,9 @@ class DataclassTestCase(TestCase):
         else:
             self.assertFalse(DataclassAdapter.is_item(AttrsItem()))
 
-        from itemadapter._imports import pydantic_v1
-
-        if pydantic_v1 is not None:
+        if PydanticModel is not None:
+            self.assertFalse(DataclassAdapter.is_item(PydanticModel()))
+        if PydanticV1Model is not None:
             self.assertFalse(DataclassAdapter.is_item(PydanticV1Model()))
 
         try:

--- a/tests/test_adapter_pydantic.py
+++ b/tests/test_adapter_pydantic.py
@@ -9,6 +9,7 @@ from tests import (
     DataClassItem,
     PydanticModel,
     PydanticSpecialCasesModel,
+    PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
     clear_itemadapter_imports,
@@ -24,10 +25,7 @@ class PydanticTestCase(unittest.TestCase):
         self.assertFalse(PydanticAdapter.is_item(sum))
         self.assertFalse(PydanticAdapter.is_item(1234))
         self.assertFalse(PydanticAdapter.is_item(object()))
-        self.assertFalse(PydanticAdapter.is_item(ScrapyItem()))
-        self.assertFalse(PydanticAdapter.is_item(AttrsItem()))
         self.assertFalse(PydanticAdapter.is_item(DataClassItem()))
-        self.assertFalse(PydanticAdapter.is_item(ScrapySubclassedItem()))
         self.assertFalse(PydanticAdapter.is_item("a string"))
         self.assertFalse(PydanticAdapter.is_item(b"some bytes"))
         self.assertFalse(PydanticAdapter.is_item({"a": "dict"}))
@@ -36,7 +34,25 @@ class PydanticTestCase(unittest.TestCase):
         self.assertFalse(PydanticAdapter.is_item({"a", "set"}))
         self.assertFalse(PydanticAdapter.is_item(PydanticModel))
 
-    @unittest.skipIf(not PydanticModel, "pydantic module is not available")
+        try:
+            import attrs  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(PydanticAdapter.is_item(AttrsItem()))
+
+        if PydanticV1Model:
+            self.assertFalse(PydanticAdapter.is_item(PydanticV1Model))
+
+        try:
+            import scrapy  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(PydanticAdapter.is_item(ScrapyItem()))
+            self.assertFalse(PydanticAdapter.is_item(ScrapySubclassedItem()))
+
+    @unittest.skipIf(not PydanticModel, "pydantic <2 module is not available")
     @mock.patch("builtins.__import__", make_mock_import("pydantic"))
     def test_module_import_error(self):
         with clear_itemadapter_imports():
@@ -48,6 +64,7 @@ class PydanticTestCase(unittest.TestCase):
 
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     @mock.patch("itemadapter.utils.pydantic", None)
+    @mock.patch("itemadapter.utils.pydantic_v1", None)
     def test_module_not_available(self):
         from itemadapter.adapter import PydanticAdapter
 
@@ -57,22 +74,52 @@ class PydanticTestCase(unittest.TestCase):
 
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
     def test_true(self):
+        from pydantic_core import PydanticUndefined
+
         from itemadapter.adapter import PydanticAdapter
 
         self.assertTrue(PydanticAdapter.is_item(PydanticModel()))
         self.assertTrue(PydanticAdapter.is_item(PydanticModel(name="asdf", value=1234)))
         # field metadata
+        mapping_proxy_type = get_field_meta_from_class(PydanticModel, "name")
         self.assertEqual(
-            get_field_meta_from_class(PydanticModel, "name"),
-            MappingProxyType({"serializer": str}),
+            mapping_proxy_type,
+            MappingProxyType(
+                {
+                    "default": PydanticUndefined,
+                    "default_factory": mapping_proxy_type["default_factory"],
+                    "json_schema_extra": {"serializer": str},
+                    "repr": True,
+                }
+            ),
         )
+        mapping_proxy_type = get_field_meta_from_class(PydanticModel, "value")
         self.assertEqual(
             get_field_meta_from_class(PydanticModel, "value"),
-            MappingProxyType({"serializer": int}),
+            MappingProxyType(
+                {
+                    "default": PydanticUndefined,
+                    "default_factory": mapping_proxy_type["default_factory"],
+                    "json_schema_extra": {"serializer": int},
+                    "repr": True,
+                }
+            ),
         )
+        mapping_proxy_type = get_field_meta_from_class(PydanticSpecialCasesModel, "special_cases")
         self.assertEqual(
-            get_field_meta_from_class(PydanticSpecialCasesModel, "special_cases"),
-            MappingProxyType({"alias": "special_cases", "allow_mutation": False}),
+            mapping_proxy_type,
+            MappingProxyType(
+                {
+                    "default": PydanticUndefined,
+                    "default_factory": mapping_proxy_type["default_factory"],
+                    "alias": "special_cases",
+                    "alias_priority": 2,
+                    "validation_alias": "special_cases",
+                    "serialization_alias": "special_cases",
+                    "frozen": True,
+                    "repr": True,
+                }
+            ),
         )
         with self.assertRaises(KeyError, msg="PydanticModel does not support field: non_existent"):
             get_field_meta_from_class(PydanticModel, "non_existent")

--- a/tests/test_adapter_pydantic.py
+++ b/tests/test_adapter_pydantic.py
@@ -9,7 +9,6 @@ from tests import (
     DataClassItem,
     PydanticModel,
     PydanticSpecialCasesModel,
-    PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
     clear_itemadapter_imports,
@@ -40,9 +39,6 @@ class PydanticTestCase(unittest.TestCase):
             pass
         else:
             self.assertFalse(PydanticAdapter.is_item(AttrsItem()))
-
-        if PydanticV1Model:
-            self.assertFalse(PydanticAdapter.is_item(PydanticV1Model))
 
         try:
             import scrapy  # noqa: F401

--- a/tests/test_adapter_pydantic_v1.py
+++ b/tests/test_adapter_pydantic_v1.py
@@ -18,43 +18,43 @@ from tests import (
 
 class PydanticTestCase(unittest.TestCase):
     def test_false(self):
-        from itemadapter.adapter import PydanticV1Adapter
+        from itemadapter.adapter import PydanticAdapter
 
-        self.assertFalse(PydanticV1Adapter.is_item(int))
-        self.assertFalse(PydanticV1Adapter.is_item(sum))
-        self.assertFalse(PydanticV1Adapter.is_item(1234))
-        self.assertFalse(PydanticV1Adapter.is_item(object()))
-        self.assertFalse(PydanticV1Adapter.is_item(DataClassItem()))
-        self.assertFalse(PydanticV1Adapter.is_item("a string"))
-        self.assertFalse(PydanticV1Adapter.is_item(b"some bytes"))
-        self.assertFalse(PydanticV1Adapter.is_item({"a": "dict"}))
-        self.assertFalse(PydanticV1Adapter.is_item(["a", "list"]))
-        self.assertFalse(PydanticV1Adapter.is_item(("a", "tuple")))
-        self.assertFalse(PydanticV1Adapter.is_item({"a", "set"}))
-        self.assertFalse(PydanticV1Adapter.is_item(PydanticV1Model))
+        self.assertFalse(PydanticAdapter.is_item(int))
+        self.assertFalse(PydanticAdapter.is_item(sum))
+        self.assertFalse(PydanticAdapter.is_item(1234))
+        self.assertFalse(PydanticAdapter.is_item(object()))
+        self.assertFalse(PydanticAdapter.is_item(DataClassItem()))
+        self.assertFalse(PydanticAdapter.is_item("a string"))
+        self.assertFalse(PydanticAdapter.is_item(b"some bytes"))
+        self.assertFalse(PydanticAdapter.is_item({"a": "dict"}))
+        self.assertFalse(PydanticAdapter.is_item(["a", "list"]))
+        self.assertFalse(PydanticAdapter.is_item(("a", "tuple")))
+        self.assertFalse(PydanticAdapter.is_item({"a", "set"}))
+        self.assertFalse(PydanticAdapter.is_item(PydanticV1Model))
 
         try:
             import attrs  # noqa: F401
         except ImportError:
             pass
         else:
-            self.assertFalse(PydanticV1Adapter.is_item(AttrsItem()))
+            self.assertFalse(PydanticAdapter.is_item(AttrsItem()))
 
         try:
             import scrapy  # noqa: F401
         except ImportError:
             pass
         else:
-            self.assertFalse(PydanticV1Adapter.is_item(ScrapyItem()))
-            self.assertFalse(PydanticV1Adapter.is_item(ScrapySubclassedItem()))
+            self.assertFalse(PydanticAdapter.is_item(ScrapyItem()))
+            self.assertFalse(PydanticAdapter.is_item(ScrapySubclassedItem()))
 
     @unittest.skipIf(not PydanticV1Model, "pydantic <2 module is not available")
     @mock.patch("builtins.__import__", make_mock_import("pydantic"))
     def test_module_import_error(self):
         with clear_itemadapter_imports():
-            from itemadapter.adapter import PydanticV1Adapter
+            from itemadapter.adapter import PydanticAdapter
 
-            self.assertFalse(PydanticV1Adapter.is_item(PydanticV1Model(name="asdf", value=1234)))
+            self.assertFalse(PydanticAdapter.is_item(PydanticV1Model(name="asdf", value=1234)))
             with self.assertRaises(TypeError, msg="PydanticV1Model is not a valid item class"):
                 get_field_meta_from_class(PydanticV1Model, "name")
 
@@ -62,18 +62,18 @@ class PydanticTestCase(unittest.TestCase):
     @mock.patch("itemadapter.utils.pydantic", None)
     @mock.patch("itemadapter.utils.pydantic_v1", None)
     def test_module_not_available(self):
-        from itemadapter.adapter import PydanticV1Adapter
+        from itemadapter.adapter import PydanticAdapter
 
-        self.assertFalse(PydanticV1Adapter.is_item(PydanticV1Model(name="asdf", value=1234)))
+        self.assertFalse(PydanticAdapter.is_item(PydanticV1Model(name="asdf", value=1234)))
         with self.assertRaises(TypeError, msg="PydanticV1Model is not a valid item class"):
             get_field_meta_from_class(PydanticV1Model, "name")
 
     @unittest.skipIf(not PydanticV1Model, "pydantic module is not available")
     def test_true(self):
-        from itemadapter.adapter import PydanticV1Adapter
+        from itemadapter.adapter import PydanticAdapter
 
-        self.assertTrue(PydanticV1Adapter.is_item(PydanticV1Model()))
-        self.assertTrue(PydanticV1Adapter.is_item(PydanticV1Model(name="asdf", value=1234)))
+        self.assertTrue(PydanticAdapter.is_item(PydanticV1Model()))
+        self.assertTrue(PydanticAdapter.is_item(PydanticV1Model(name="asdf", value=1234)))
         # field metadata
         self.assertEqual(
             get_field_meta_from_class(PydanticV1Model, "name"),

--- a/tests/test_adapter_pydantic_v1.py
+++ b/tests/test_adapter_pydantic_v1.py
@@ -1,0 +1,106 @@
+import unittest
+import warnings
+from types import MappingProxyType
+from unittest import mock
+
+from itemadapter.utils import get_field_meta_from_class
+from tests import (
+    AttrsItem,
+    DataClassItem,
+    PydanticV1Model,
+    PydanticV1SpecialCasesModel,
+    ScrapyItem,
+    ScrapySubclassedItem,
+    clear_itemadapter_imports,
+    make_mock_import,
+)
+
+
+class PydanticTestCase(unittest.TestCase):
+    def test_false(self):
+        from itemadapter.adapter import PydanticV1Adapter
+
+        self.assertFalse(PydanticV1Adapter.is_item(int))
+        self.assertFalse(PydanticV1Adapter.is_item(sum))
+        self.assertFalse(PydanticV1Adapter.is_item(1234))
+        self.assertFalse(PydanticV1Adapter.is_item(object()))
+        self.assertFalse(PydanticV1Adapter.is_item(DataClassItem()))
+        self.assertFalse(PydanticV1Adapter.is_item("a string"))
+        self.assertFalse(PydanticV1Adapter.is_item(b"some bytes"))
+        self.assertFalse(PydanticV1Adapter.is_item({"a": "dict"}))
+        self.assertFalse(PydanticV1Adapter.is_item(["a", "list"]))
+        self.assertFalse(PydanticV1Adapter.is_item(("a", "tuple")))
+        self.assertFalse(PydanticV1Adapter.is_item({"a", "set"}))
+        self.assertFalse(PydanticV1Adapter.is_item(PydanticV1Model))
+
+        try:
+            import attrs  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(PydanticV1Adapter.is_item(AttrsItem()))
+
+        try:
+            import scrapy  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(PydanticV1Adapter.is_item(ScrapyItem()))
+            self.assertFalse(PydanticV1Adapter.is_item(ScrapySubclassedItem()))
+
+    @unittest.skipIf(not PydanticV1Model, "pydantic <2 module is not available")
+    @mock.patch("builtins.__import__", make_mock_import("pydantic"))
+    def test_module_import_error(self):
+        with clear_itemadapter_imports():
+            from itemadapter.adapter import PydanticV1Adapter
+
+            self.assertFalse(PydanticV1Adapter.is_item(PydanticV1Model(name="asdf", value=1234)))
+            with self.assertRaises(TypeError, msg="PydanticV1Model is not a valid item class"):
+                get_field_meta_from_class(PydanticV1Model, "name")
+
+    @unittest.skipIf(not PydanticV1Model, "pydantic module is not available")
+    @mock.patch("itemadapter.utils.pydantic", None)
+    @mock.patch("itemadapter.utils.pydantic_v1", None)
+    def test_module_not_available(self):
+        from itemadapter.adapter import PydanticV1Adapter
+
+        self.assertFalse(PydanticV1Adapter.is_item(PydanticV1Model(name="asdf", value=1234)))
+        with self.assertRaises(TypeError, msg="PydanticV1Model is not a valid item class"):
+            get_field_meta_from_class(PydanticV1Model, "name")
+
+    @unittest.skipIf(not PydanticV1Model, "pydantic module is not available")
+    def test_true(self):
+        from itemadapter.adapter import PydanticV1Adapter
+
+        self.assertTrue(PydanticV1Adapter.is_item(PydanticV1Model()))
+        self.assertTrue(PydanticV1Adapter.is_item(PydanticV1Model(name="asdf", value=1234)))
+        # field metadata
+        self.assertEqual(
+            get_field_meta_from_class(PydanticV1Model, "name"),
+            MappingProxyType({"serializer": str}),
+        )
+        self.assertEqual(
+            get_field_meta_from_class(PydanticV1Model, "value"),
+            MappingProxyType({"serializer": int}),
+        )
+        self.assertEqual(
+            get_field_meta_from_class(PydanticV1SpecialCasesModel, "special_cases"),
+            MappingProxyType({"alias": "special_cases", "allow_mutation": False}),
+        )
+        with self.assertRaises(
+            KeyError, msg="PydanticV1Model does not support field: non_existent"
+        ):
+            get_field_meta_from_class(PydanticV1Model, "non_existent")
+
+    def test_deprecated_is_instance(self):
+        from itemadapter.utils import is_pydantic_instance
+
+        with warnings.catch_warnings(record=True) as caught:
+            is_pydantic_instance(1)
+            self.assertEqual(len(caught), 1)
+            self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
+            self.assertEqual(
+                "itemadapter.utils.is_pydantic_instance is deprecated"
+                " and it will be removed in a future version",
+                str(caught[0].message),
+            )

--- a/tests/test_adapter_scrapy.py
+++ b/tests/test_adapter_scrapy.py
@@ -7,6 +7,7 @@ from itemadapter.utils import get_field_meta_from_class
 from tests import (
     AttrsItem,
     DataClassItem,
+    PydanticModel,
     PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
@@ -39,9 +40,9 @@ class ScrapyItemTestCase(unittest.TestCase):
         else:
             self.assertFalse(ScrapyItemAdapter.is_item(AttrsItem()))
 
-        from itemadapter._imports import pydantic_v1
-
-        if pydantic_v1 is not None:
+        if PydanticModel is not None:
+            self.assertFalse(ScrapyItemAdapter.is_item(PydanticModel()))
+        if PydanticV1Model is not None:
             self.assertFalse(ScrapyItemAdapter.is_item(PydanticV1Model()))
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")

--- a/tests/test_adapter_scrapy.py
+++ b/tests/test_adapter_scrapy.py
@@ -7,7 +7,7 @@ from itemadapter.utils import get_field_meta_from_class
 from tests import (
     AttrsItem,
     DataClassItem,
-    PydanticModel,
+    PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
     clear_itemadapter_imports,
@@ -23,9 +23,7 @@ class ScrapyItemTestCase(unittest.TestCase):
         self.assertFalse(ScrapyItemAdapter.is_item(sum))
         self.assertFalse(ScrapyItemAdapter.is_item(1234))
         self.assertFalse(ScrapyItemAdapter.is_item(object()))
-        self.assertFalse(ScrapyItemAdapter.is_item(AttrsItem()))
         self.assertFalse(ScrapyItemAdapter.is_item(DataClassItem()))
-        self.assertFalse(ScrapyItemAdapter.is_item(PydanticModel()))
         self.assertFalse(ScrapyItemAdapter.is_item("a string"))
         self.assertFalse(ScrapyItemAdapter.is_item(b"some bytes"))
         self.assertFalse(ScrapyItemAdapter.is_item({"a": "dict"}))
@@ -33,6 +31,18 @@ class ScrapyItemTestCase(unittest.TestCase):
         self.assertFalse(ScrapyItemAdapter.is_item(("a", "tuple")))
         self.assertFalse(ScrapyItemAdapter.is_item({"a", "set"}))
         self.assertFalse(ScrapyItemAdapter.is_item(ScrapySubclassedItem))
+
+        try:
+            import attrs  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            self.assertFalse(ScrapyItemAdapter.is_item(AttrsItem()))
+
+        from itemadapter._imports import pydantic_v1
+
+        if pydantic_v1 is not None:
+            self.assertFalse(ScrapyItemAdapter.is_item(PydanticV1Model()))
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
     @mock.patch("builtins.__import__", make_mock_import("scrapy"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from itemadapter.utils import get_field_meta_from_class, is_item
 from tests import (
     AttrsItem,
     DataClassItem,
-    PydanticModel,
+    PydanticV1Model,
     ScrapyItem,
     ScrapySubclassedItem,
 )
@@ -43,7 +43,7 @@ class ItemLikeTestCase(unittest.TestCase):
         self.assertFalse(is_item(DataClassItem))
         self.assertFalse(is_item(ScrapySubclassedItem))
         self.assertFalse(is_item(AttrsItem))
-        self.assertFalse(is_item(PydanticModel))
+        self.assertFalse(is_item(PydanticV1Model))
         self.assertFalse(ItemAdapter.is_item_class(list))
         self.assertFalse(ItemAdapter.is_item_class(int))
         self.assertFalse(ItemAdapter.is_item_class(tuple))
@@ -69,7 +69,7 @@ class ItemLikeTestCase(unittest.TestCase):
         self.assertTrue(is_item(AttrsItem(name="asdf", value=1234)))
         self.assertTrue(ItemAdapter.is_item_class(AttrsItem))
 
-    @unittest.skipIf(not PydanticModel, "pydantic module is not available")
+    @unittest.skipIf(not PydanticV1Model, "pydantic module is not available")
     def test_true_pydantic(self):
-        self.assertTrue(is_item(PydanticModel(name="asdf", value=1234)))
-        self.assertTrue(ItemAdapter.is_item_class(PydanticModel))
+        self.assertTrue(is_item(PydanticV1Model(name="asdf", value=1234)))
+        self.assertTrue(ItemAdapter.is_item_class(PydanticV1Model))

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,19 @@
 [tox]
-envlist = min-attrs,min-pydantic,min-scrapy,py39,py310,py311,py312,py313,attrs,pydantic1,pydantic,scrapy,pre-commit,typing,docs,twinecheck,pylint
+envlist = min-attrs,min-pydantic,min-scrapy,min-extra,py39,py310,py311,py312,py313,attrs,pydantic1,pydantic,scrapy,extra,extra-pydantic1,pre-commit,typing,docs,twinecheck,pylint
 
 [testenv]
 basepython =
-    min-attrs,min-pydantic,min-scrapy: python3.9
+    min-attrs,min-pydantic,min-scrapy,min-extra: python3.9
 deps =
     -rtests/requirements.txt
-    min-attrs: attrs==18.1.0
-    min-pydantic: pydantic==1.8
-    min-scrapy: scrapy==2.2
-    pydantic1: pydantic<2
+    min-attrs,min-extra: attrs==18.1.0
+    min-pydantic,min-extra: pydantic==1.8
+    min-scrapy,min-extra: scrapy==2.2
+    pydantic1,extra-pydantic1: pydantic<2
 extras =
-    min-attrs,attrs: attrs
-    min-pydantic,pydantic1,pydantic: pydantic
-    min-scrapy,scrapy: scrapy
+    min-attrs,attrs,min-extra,extra,extra-pydantic1: attrs
+    min-pydantic,pydantic1,pydantic,min-extra,extra,extra-pydantic1: pydantic
+    min-scrapy,scrapy,min-extra,extra,extra-pydantic1: scrapy
 commands =
     pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: itemadapter tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,32 @@
 [tox]
-envlist = typing,py,py38-scrapy22,pylint,py-pydantic1,pre-commit,twinecheck
+envlist = min-attrs,min-pydantic,min-scrapy,py39,py310,py311,py312,py313,attrs,pydantic1,pydantic,scrapy,pre-commit,typing,docs,twinecheck,pylint
 
 [testenv]
+basepython =
+    min-attrs,min-pydantic,min-scrapy: python3.9
 deps =
     -rtests/requirements.txt
-    py39-scrapy22: scrapy==2.2
-    py-pydantic1: pydantic<2
+    min-attrs: attrs==18.1.0
+    min-pydantic: pydantic==1.8
+    min-scrapy: scrapy==2.2
+    pydantic1: pydantic<2
+extras =
+    min-attrs,attrs: attrs
+    min-pydantic,pydantic1,pydantic: pydantic
+    min-scrapy,scrapy: scrapy
 commands =
-    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --doctest-glob=README.md {posargs: itemadapter README.md tests}
+    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml {posargs: itemadapter tests}
+
+[testenv:docs]
+deps =
+    {[testenv]deps}
+    zyte-common-items
+extras =
+    attrs
+    pydantic
+    scrapy
+commands =
+    pytest --verbose --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --doctest-glob=README.md {posargs:README.md}
 
 [testenv:typing]
 basepython = python3


### PR DESCRIPTION
Continuation of #86 with the following additional changes:
- The itemadapter API remains backward compatible (no separate `PydanticV1Adapter` class).
- Add extras for attrs, pydantic and scrapy, so that users can make sure they get the right versions of those packages (and potential future dependencies related to them) when installing them for itemadapter.
- Create separate tox envs for attrs, pydantic, scrapy, and combining all of them. Test with minimum and latest versions. For Pydantic, also test with the latest 1.x version. The regular tox envs do not install those dependencies.
- Create a separate `docs` tox env to check the README code.
- Updated the README to reflect the output with the latest pydantic version.
- Replace the README ADAPTER_CLASSES example that requires cloning the repo (uses tests/ code) with one that installs a third-party package instead (zyte-common-items). I think the code is more readable, and it’s good to point to a real example of a custom adapter.

Resolves #72, closes #76, closes #86.