### PR TITLE
Release notes for version 0.13.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 0.13.1 (unreleased)
+
+Fixed `get_json_schema()` to properly format multiline field docstrings using
+`inspect.cleandoc()`, ensuring consistent indentation and whitespace handling
+([#115](https://github.com/scrapy/itemadapter/pull/115)).
+
 ### 0.13.0 (2025-12-15)
 
 Added support for Python 3.14 and removed support for [PyPy](https://pypy.org/)
@@ -35,10 +41,10 @@ and using [ruff](https://docs.astral.sh/ruff/)
 
 Removed functions deprecated in 0.5.0:
 
-* `itemadapter.utils.is_attrs_instance()`
-* `itemadapter.utils.is_dataclass_instance()`
-* `itemadapter.utils.is_pydantic_instance()`
-* `itemadapter.utils.is_scrapy_item()`
+- `itemadapter.utils.is_attrs_instance()`
+- `itemadapter.utils.is_dataclass_instance()`
+- `itemadapter.utils.is_pydantic_instance()`
+- `itemadapter.utils.is_scrapy_item()`
 
 ([#93](https://github.com/scrapy/itemadapter/pull/93)).
 
@@ -84,7 +90,6 @@ Updated CI configuration
 ([#77](https://github.com/scrapy/itemadapter/pull/77),
 [#80](https://github.com/scrapy/itemadapter/pull/80)).
 
-
 ### 0.8.0 (2023-03-30)
 
 Dropped Python 3.6 support, and made Python 3.11 support official
@@ -100,42 +105,35 @@ different parts of the same code base
 Improved type hint support
 ([#67](https://github.com/scrapy/itemadapter/pull/67)).
 
-
 ### 0.7.0 (2022-08-02)
 
 ItemAdapter.get_field_names_from_class
 ([#64](https://github.com/scrapy/itemadapter/pull/64))
-
 
 ### 0.6.0 (2022-05-12)
 
 Slight performance improvement
 ([#62](https://github.com/scrapy/itemadapter/pull/62))
 
-
 ### 0.5.0 (2022-03-18)
 
 Improve performance by removing imports inside functions
 ([#60](https://github.com/scrapy/itemadapter/pull/60))
-
 
 ### 0.4.0 (2021-08-26)
 
 Added `ItemAdapter.is_item_class` and `ItemAdapter.get_field_meta_from_class`
 ([#54](https://github.com/scrapy/itemadapter/pull/54))
 
-
 ### 0.3.0 (2021-07-15)
 
 Added built-in support for `pydantic` models ([#53](https://github.com/scrapy/itemadapter/pull/53))
-
 
 ### 0.2.0 (2020-11-06)
 
 Adapter interface: added the ability to support arbitrary types,
 by implementing a MutableMapping-based interface.
 By way of this change, now any type can be used as a Scrapy item.
-
 
 ### 0.1.1 (2020-09-28)
 
@@ -150,7 +148,6 @@ item (#31, #41).
 
 Minor improvement to the release process (#37), and cleanup of test warnings (#40).
 
-
 ### 0.1.0 (2020-06-10)
 
 Added `ItemAdapter.asdict`, which allows converting an item and all of its
@@ -159,13 +156,11 @@ nested items into `dict` objects (#27, #29).
 Improved `ItemAdapter` performance by reducing time complexity for lookups and
 traversals for dataclass and attrs items (#28).
 
-
 ### 0.0.8 (2020-05-22)
 
 `ItemAdapter.field_names` now returns a `KeysView` instead of a `list`.
 
 Minor CI and test changes.
-
 
 ### 0.0.7 (2020-05-22)
 
@@ -177,7 +172,6 @@ Improved the README and some docstrings.
 Provided full test coverage, and refactored CI configuration, test
 configuration and tests themselves.
 
-
 ### 0.0.6 (2020-05-09)
 
 Added support for Scrapy’s `BaseItem`.
@@ -186,21 +180,17 @@ Refactored and extended tests.
 
 Code style and documentation fixes.
 
-
 ### 0.0.5 (2020-04-28)
 
 Removed support for `MutableMapping`.
-
 
 ### 0.0.4 (2020-04-28)
 
 Removed metadata support for arbitrary mutable mappings.
 
-
 ### 0.0.3 (2020-04-27)
 
 Rebuild for the Python Package Index.
-
 
 ### 0.0.2 (2020-04-27)
 
@@ -208,7 +198,6 @@ Split the implementation into several files for better code organization, and
 without an impact on the existing API import paths.
 
 Also improved the README.
-
 
 ### 0.0.1 (2020-04-25)
 


### PR DESCRIPTION
Add release notes for version 0.13.1, which includes the fix for properly formatting multiline field docstrings in JSON schema using inspect.cleandoc() [#115](https://github.com/scrapy/itemadapter/pull/115)