### PR TITLE
Fix ADAPTER_CLASSES type annotation from Iterable to deque

### DIFF
--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -366,7 +366,7 @@ class ItemAdapter(MutableMapping):
     to extract and set data without having to take the object's type into account.
     """
 
-    ADAPTER_CLASSES: Iterable[type[AdapterInterface]] = deque(
+    ADAPTER_CLASSES: deque[type[AdapterInterface]] = deque(
         [
             ScrapyItemAdapter,
             DictAdapter,


### PR DESCRIPTION
`ADAPTER_CLASSES` is initialized as a `deque` and users are expected to call `.appendleft()` and `.append()` on it (as shown in the docs). However, the type annotation says `Iterable[type[AdapterInterface]]`, which is misleading since `Iterable` does not have those methods.

The annotation should be `deque[type[AdapterInterface]]` to match the actual type and expose the correct interface to type checkers.

The `deque` import is already in the file (`from collections import deque`), so no new imports are needed.

Closes #82