### PR TITLE
Add clone() method to the item interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,12 @@ with the names of all the defined fields for the item.
 Return a `dict` object with the contents of the adapter. This works slightly different than
 calling `dict(adapter)`, because it's applied recursively to nested items (if there are any).
 
+#### `clone(deep: bool = True) -> ItemAdapter`
+
+Return a new `ItemAdapter` object, wrapping a copy of the underlying item. If
+`deep` is `True` (the default), a deep copy of the item is made (i.e., nested
+values are copied as well); otherwise, a shallow copy is made.
+
 
 ### function `itemadapter.utils.is_item(obj: Any) -> bool`
 
@@ -487,6 +493,17 @@ so all methods from the `MutableMapping` interface must be implemented as well.
 
     You might want to override this method if you want a way to get all fields for an item, whether or not
     they are populated. For instance, Scrapy uses this method to define column names when exporting items to CSV.
+
+* _method `clone(self, deep: bool = True) -> Any`_:
+
+    Return a copy of the item. If `deep` is `True` (the default), return a
+    deep copy; otherwise, return a shallow copy. The default implementation
+    applies [`copy.deepcopy()`](https://docs.python.org/3/library/copy.html#copy.deepcopy)
+    or [`copy.copy()`](https://docs.python.org/3/library/copy.html#copy.copy),
+    depending on the value of `deep`. You might want to override this method
+    if your item type needs custom copy logic, e.g., if the default
+    shallow copy of your item would share mutable internal state between the
+    original and the copy.
 
 ### Registering an adapter
 

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -4,6 +4,7 @@ import dataclasses
 from abc import ABCMeta, abstractmethod
 from collections import deque
 from collections.abc import Iterable, Iterator, KeysView, MutableMapping
+from copy import copy, deepcopy
 from types import MappingProxyType
 from typing import Any
 
@@ -81,6 +82,13 @@ class AdapterInterface(MutableMapping, metaclass=ABCMeta):
     def field_names(self) -> KeysView:
         """Return a dynamic view of the item's field names."""
         return self.keys()  # type: ignore[return-value]
+
+    def clone(self, *, deep: bool = True) -> Any:
+        """Return a copy of the item. If ``deep`` is True (the default), a deep
+        copy is returned; otherwise, a shallow copy is returned."""
+        if deep:
+            return deepcopy(self.item)
+        return copy(self.item)
 
 
 class _MixinAttrsDataclassAdapter:
@@ -289,6 +297,12 @@ class PydanticAdapter(AdapterInterface):
     def __len__(self) -> int:
         return len(list(iter(self)))
 
+    def clone(self, *, deep: bool = True) -> Any:
+        try:
+            return self.item.model_copy(deep=deep)
+        except AttributeError:
+            return self.item.copy(deep=deep)
+
 
 class _MixinDictScrapyItemAdapter:
     _fields_dict: dict
@@ -359,6 +373,13 @@ class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
 
     def field_names(self) -> KeysView:
         return KeysView(self.item.fields)
+
+    def clone(self, *, deep: bool = True) -> Any:
+        if deep:
+            return deepcopy(self.item)
+        # copy.copy() would share the internal value storage between the
+        # original item and the copy.
+        return self.item.__class__(self.item)
 
 
 class ItemAdapter(MutableMapping):
@@ -467,3 +488,9 @@ class ItemAdapter(MutableMapping):
         if cls.is_item(obj):
             return cls(obj).asdict()
         return obj
+
+    def clone(self, *, deep: bool = True) -> ItemAdapter:
+        """Return a new ItemAdapter object wrapping a copy of the underlying item.
+        If ``deep`` is True (the default), a deep copy of the item is made;
+        otherwise, a shallow copy is made."""
+        return self.__class__(self.adapter.clone(deep=deep))

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -165,6 +165,55 @@ class BaseTestMixin:
             "int_": 123,
         }
 
+    def test_clone(self):
+        item = self.item_class(name="asdf", value=1234)
+        adapter = ItemAdapter(item)
+        clone = adapter.clone()
+        assert isinstance(clone, ItemAdapter)
+        assert clone is not adapter
+        assert clone.item is not item
+        assert dict(clone) == {"name": "asdf", "value": 1234}
+        clone["name"] = "foo"
+        assert clone["name"] == "foo"
+        assert adapter["name"] == "asdf"
+
+    def test_clone_nested(self):
+        item = self.item_class_nested(
+            nested=self.item_class(name="asdf", value=1234),
+            adapter=ItemAdapter({"foo": "bar", "nested_list": [1, 2, 3, 4, 5]}),
+            dict_={"foo": "bar", "answer": 42, "nested_dict": {"a": "b"}},
+            list_=[1, 2, 3],
+            set_={1, 2, 3},
+            tuple_=(1, 2, 3),
+            int_=123,
+        )
+        adapter = ItemAdapter(item)
+        clone = adapter.clone()
+        assert clone.item is not item
+        assert clone.asdict() == adapter.asdict()
+        assert clone["dict_"] is not adapter["dict_"]
+        assert clone["nested"] is not adapter["nested"]
+        clone_nested = ItemAdapter(clone["nested"])
+        clone_nested["name"] = "changed"
+        assert ItemAdapter(adapter["nested"])["name"] == "asdf"
+
+    def test_clone_shallow(self):
+        item = self.item_class_nested(
+            nested=self.item_class(name="asdf", value=1234),
+            adapter=ItemAdapter({"foo": "bar", "nested_list": [1, 2, 3, 4, 5]}),
+            dict_={"foo": "bar", "answer": 42, "nested_dict": {"a": "b"}},
+            list_=[1, 2, 3],
+            set_={1, 2, 3},
+            tuple_=(1, 2, 3),
+            int_=123,
+        )
+        adapter = ItemAdapter(item)
+        clone = adapter.clone(deep=False)
+        assert clone.item is not item
+        assert clone.asdict() == adapter.asdict()
+        assert clone["dict_"] is adapter["dict_"]
+        assert clone["nested"] is adapter["nested"]
+
     def test_field_names(self):
         item = self.item_class(name="asdf", value=1234)
         adapter = ItemAdapter(item)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -184,6 +184,24 @@ class BaseFakeItemAdapterTest(unittest.TestCase):
         assert isinstance(adapter.field_names(), KeysView)
         assert sorted(adapter.field_names()) == ["name", "value"]
 
+    def test_clone(self):
+        item = self.item_class(name="asdf", value=1234)
+        adapter = ItemAdapter(item)
+        clone = adapter.clone()
+        assert isinstance(clone, ItemAdapter)
+        assert clone.item is not item
+        assert dict(clone) == {"name": "asdf", "value": 1234}
+        clone["name"] = "foo"
+        assert clone["name"] == "foo"
+        assert adapter["name"] == "asdf"
+
+    def test_clone_shallow(self):
+        item = self.item_class(name="asdf", value=1234)
+        adapter = ItemAdapter(item)
+        clone = adapter.clone(deep=False)
+        assert clone.item is not item
+        assert dict(clone) == {"name": "asdf", "value": 1234}
+
 
 class MetadataFakeItemAdapterTest(BaseFakeItemAdapterTest):
     item_class = FakeItemClass

--- a/tests/test_itemadapter.py
+++ b/tests/test_itemadapter.py
@@ -15,3 +15,18 @@ class ItemAdapterTestCase(unittest.TestCase):
     def test_repr_subclass(self):
         adapter = DictOnlyItemAdapter({"foo": "bar"})
         assert repr(adapter) == "<DictOnlyItemAdapter for dict(foo='bar')>"
+
+    def test_clone(self):
+        adapter = ItemAdapter({"foo": "bar"})
+        clone = adapter.clone()
+        assert isinstance(clone, ItemAdapter)
+        assert clone is not adapter
+        assert clone.item is not adapter.item
+        assert dict(clone) == {"foo": "bar"}
+
+    def test_clone_subclass(self):
+        adapter = DictOnlyItemAdapter({"foo": "bar"})
+        clone = adapter.clone()
+        assert clone.__class__ is DictOnlyItemAdapter
+        assert clone.item is not adapter.item
+        assert dict(clone) == {"foo": "bar"}


### PR DESCRIPTION
Add a `clone()` method to the item interface ([#124](https://github.com/scrapy/itemadapter/issues/124)).

- `AdapterInterface.clone(*, deep=True)` returns a copy of the wrapped item:
  a deep copy by default (`copy.deepcopy`), or a shallow copy (`copy.copy`)
  when `deep=False`.
- `ItemAdapter.clone(*, deep=True)` returns a new `ItemAdapter` object (or an
  instance of the corresponding subclass) wrapping the copy.
- `PydanticAdapter` overrides `clone()` to use the native
  `model_copy(deep=...)` / `copy(deep=...)` methods.
- `ScrapyItemAdapter` overrides `clone()` so that a shallow copy does not
  share the internal value storage between the original item and the copy.

Includes tests for all supported item types (deep/shallow copies, nested
items, default implementation for custom adapters, subclass behavior) and
documentation updates in the README.

Closes #124