### PR TITLE
Add CodSpeed benchmarks for is_item()

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,9 +7,13 @@ on:
     - '[0-9]+.[0-9]+'
   pull_request:
 
+permissions: {}
+
 jobs:
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -28,10 +32,12 @@ jobs:
             TOXENV: pylint
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -44,6 +50,10 @@ jobs:
 
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v6
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,47 @@
+name: CodSpeed
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    paths:
+    - itemadapter/**
+    - tests/benchmarks/**
+    - .github/workflows/codspeed.yml
+    - tox.ini
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # OIDC authentication with CodSpeed
+
+    steps:
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        python-version: "3.13"
+
+    - name: Install dependencies
+      run: |
+        pip install tox
+        tox -n -e benchmark
+
+    - name: Run benchmarks
+      uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+      with:
+        mode: simulation
+        run: tox -e benchmark

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,12 +12,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.14"
     - run: |
         python -m pip install --upgrade build
         python -m build
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,15 @@ on:
     - '[0-9]+.[0-9]+'
   pull_request:
 
+permissions: {}
+
 jobs:
   tests-ubuntu:
     name: "Test: ${{ matrix.python-version }}, Ubuntu"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # OIDC authentication with Codecov
     strategy:
       fail-fast: false
       matrix:
@@ -68,10 +73,12 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -83,20 +90,25 @@ jobs:
       run: tox
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
 
   tests-other-os:
     name: "Test: py310, ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
+    permissions:
+      contents: read
+      id-token: write  # OIDC authentication with Codecov
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.10"
 
@@ -107,4 +119,4 @@ jobs:
       run: tox -e py
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
   rev: v1.7.11
   hooks:
     - id: actionlint
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.29.0
+  hooks:
+    - id: zizmor
+      args: [--no-progress, --fix]

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.importorskip("pytest_codspeed", reason="Benchmarks require pytest-codspeed")

--- a/tests/benchmarks/test_is_item.py
+++ b/tests/benchmarks/test_is_item.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import field, make_dataclass
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+import itemadapter
+from itemadapter import ItemAdapter
+from itemadapter._imports import attr, pydantic, pydantic_v1, scrapy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from pytest_codspeed import BenchmarkFixture
+
+# Number of calls per benchmark. Kept the same for every scenario so that the
+# results of different scenarios can be compared to each other.
+CALLS = 100
+
+
+def _dict_class(index: int) -> type:
+    return type(f"DictItem{index}", (dict,), {})
+
+
+def _dataclass_class(index: int) -> type:
+    return make_dataclass(
+        f"DataClassItem{index}",
+        [("name", str, field(default=None)), ("value", int, field(default=None))],
+    )
+
+
+def _non_item_class(index: int) -> type:
+    return type(f"NonItem{index}", (), {})
+
+
+def _attrs_class(index: int) -> type:
+    return attr.make_class(
+        f"AttrsItem{index}",
+        {"name": attr.ib(default=None), "value": attr.ib(default=None)},
+    )
+
+
+def _pydantic_class(index: int) -> type:
+    return pydantic.create_model(f"PydanticModel{index}", name=(str, None), value=(int, None))
+
+
+def _pydantic_v1_class(index: int) -> type:
+    return pydantic_v1.create_model(f"PydanticV1Model{index}", name=(str, None), value=(int, None))
+
+
+def _scrapy_class(index: int) -> type:
+    return type(scrapy.Item)(
+        f"ScrapyItem{index}",
+        (scrapy.Item,),
+        {"name": scrapy.Field(), "value": scrapy.Field()},
+    )
+
+
+ITEM_CLASS_FACTORIES: dict[str, Callable[[int], type]] = {
+    "dict": _dict_class,
+    "dataclass": _dataclass_class,
+    "non-item": _non_item_class,
+}
+if attr is not None:
+    ITEM_CLASS_FACTORIES["attrs"] = _attrs_class
+if pydantic is not None:
+    ITEM_CLASS_FACTORIES["pydantic"] = _pydantic_class
+if pydantic_v1 is not None:
+    ITEM_CLASS_FACTORIES["pydantic-v1"] = _pydantic_v1_class
+if scrapy is not None:
+    ITEM_CLASS_FACTORIES["scrapy"] = _scrapy_class
+
+item_class_factory = pytest.mark.parametrize(
+    "factory",
+    ITEM_CLASS_FACTORIES.values(),
+    ids=list(ITEM_CLASS_FACTORIES),
+)
+is_item_function = pytest.mark.parametrize(
+    "func",
+    [ItemAdapter.is_item, itemadapter.is_item],
+    ids=["ItemAdapter.is_item", "is_item"],
+)
+
+
+@is_item_function
+@item_class_factory
+def test_shared_class(
+    benchmark: BenchmarkFixture,
+    factory: Callable[[int], type],
+    func: Callable[[Any], bool],
+) -> None:
+    """Items all share a single class, as in most real usage."""
+    item_class = factory(0)
+    items = [item_class() for _ in range(CALLS)]
+
+    @benchmark
+    def _() -> None:
+        for item in items:
+            func(item)
+
+
+@is_item_function
+@item_class_factory
+def test_distinct_classes(
+    benchmark: BenchmarkFixture,
+    factory: Callable[[int], type],
+    func: Callable[[Any], bool],
+) -> None:
+    """Every item has a class that no earlier call has seen.
+
+    Item classes are built by a setup callback, which runs before every round
+    and outside the measured window, so that their creation is not measured and
+    the measured calls cannot benefit from earlier ones.
+    """
+
+    def setup() -> tuple[tuple[Any, ...], dict[str, Any]]:
+        return ([factory(index)() for index in range(CALLS)],), {}
+
+    def call(items: Sequence[Any]) -> None:
+        for item in items:
+            func(item)
+
+    benchmark.pedantic(call, setup=setup)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = min-attrs,min-pydantic,min-scrapy,min-extra,py310,py311,py312,py313,py314,attrs,pydantic1,pydantic,scrapy,extra,extra-pydantic1,pre-commit,typing,docs,twinecheck,pylint
+envlist = min-{attrs,pydantic,scrapy,extra},py{310-314},attrs,pydantic1,pydantic,scrapy,extra,extra-pydantic1,benchmark,pre-commit,typing,docs,twinecheck,pylint
+minversion = 4.25.0
 
 [testenv]
 basepython =
@@ -29,6 +30,25 @@ extras =
     scrapy
 commands =
     pytest -vv --cov=itemadapter --cov-report=term-missing --cov-report=html --cov-report=xml --doctest-glob=README.md {posargs:README.md}
+
+# CPU benchmarks, tracked on CodSpeed.
+#
+# Python 3.13 is the latest version where Pydantic 1 models can be benchmarked.
+
+[testenv:benchmark]
+basepython = python3.13
+deps =
+    pytest>=5.4
+    pytest-codspeed
+extras =
+    attrs
+    pydantic
+    scrapy
+passenv =
+    *codspeed*
+    *ci*
+commands =
+    pytest {posargs:tests/benchmarks} --codspeed --codspeed-mode=simulation
 
 [testenv:typing]
 basepython = python3


### PR DESCRIPTION
Sets the ground work to address https://github.com/scrapy/itemadapter/issues/59 in a measurable way.

I am hoping that caching will do most of the work, but the benchmarks are designed to also measure scenarios where caching by item type is not possible.