### PR TITLE
Cache which adapter class handles each item class

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,23 +175,24 @@ Stores the currently registered adapter classes.
 
 The order in which the adapters are registered is important. When an `ItemAdapter` object is
 created for a specific item, the registered adapters are traversed in order and the first
-adapter class to return `True` for the `is_item` class method is used for all subsequent
+adapter class to return `True` for the `is_item_class` class method is used for all subsequent
 operations. The default order is the one defined in the
 [built-in adapters](#built-in-adapters) section.
 
-The default implementation uses a
-[`collections.deque`](https://docs.python.org/3/library/collections.html#collections.deque)
-to support efficient addition/deletion of adapters classes to both ends, but if you are
-deriving a subclass (see the section on [extending itemadapter](#extending-itemadapter)
-for additional information), any other iterable (e.g. `list`, `tuple`) will work.
+The default implementation is a `tuple`, but any other iterable (e.g. `list`,
+[`collections.deque`](https://docs.python.org/3/library/collections.html#collections.deque))
+will work.
+
+Which adapter class handles a given item class is cached, so `is_item_class` must
+return the same result every time it is called with the same item class.
 
 **Methods**
 
 #### class method `is_item(item: Any) -> bool`
 
-Return `True` if any of the registed adapters can handle the item
-(i.e. if any of them returns `True` for its `is_item` method with
-`item` as argument), `False` otherwise.
+Return `True` if any of the registered adapters can handle the class of the item
+(i.e. if any of them returns `True` for its `is_item_class` method with
+`item.__class__` as argument), `False` otherwise.
 
 #### class method `is_item_class(item_class: type) -> bool`
 

--- a/itemadapter/_json_schema.py
+++ b/itemadapter/_json_schema.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from ._imports import PydanticUndefined, PydanticV1Undefined, attr
-from .utils import _is_pydantic_model
+from ._utils import _is_pydantic_model
 
 if TYPE_CHECKING:
     from .adapter import AdapterInterface, ItemAdapter

--- a/itemadapter/_utils.py
+++ b/itemadapter/_utils.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+
+from itemadapter._imports import (
+    PydanticUndefined,
+    PydanticV1Undefined,
+    attr,
+    pydantic,
+    pydantic_v1,
+)
+
+
+def _is_attrs_class(obj: Any) -> bool:
+    if attr is None:
+        return False
+    return attr.has(obj)
+
+
+def _is_pydantic_model(obj: Any) -> bool:
+    if pydantic is None:
+        return False
+    return issubclass(obj, pydantic.BaseModel)
+
+
+def _is_pydantic_v1_model(obj: Any) -> bool:
+    if pydantic_v1 is None:
+        return False
+    return issubclass(obj, pydantic_v1.BaseModel)
+
+
+def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
+    metadata = {}
+    field = item_model.model_fields[field_name]
+
+    for attribute in [
+        "alias_priority",
+        "alias",
+        "allow_inf_nan",
+        "annotation",
+        "coerce_numbers_to_str",
+        "decimal_places",
+        "default_factory",
+        "deprecated",
+        "description",
+        "discriminator",
+        "examples",
+        "exclude",
+        "fail_fast",
+        "field_title_generator",
+        "frozen",
+        "ge",
+        "gt",
+        "init_var",
+        "init",
+        "json_schema_extra",
+        "kw_only",
+        "le",
+        "lt",
+        "max_digits",
+        "max_length",
+        "min_length",
+        "multiple_of",
+        "pattern",
+        "repr",
+        "serialization_alias",
+        "strict",
+        "title",
+        "union_mode",
+        "validate_default",
+        "validation_alias",
+    ]:
+        if hasattr(field, attribute) and (value := getattr(field, attribute)) is not None:
+            metadata[attribute] = value
+
+    for attribute, default_value in [
+        ("default", PydanticUndefined),
+        ("metadata", []),
+    ]:
+        if hasattr(field, attribute) and (value := getattr(field, attribute)) != default_value:
+            metadata[attribute] = value
+
+    return MappingProxyType(metadata)
+
+
+def _get_pydantic_v1_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
+    metadata = {}
+    field = item_model.__fields__[field_name]
+    field_info = field.field_info
+
+    for attribute in [
+        "alias",
+        "const",
+        "description",
+        "ge",
+        "gt",
+        "le",
+        "lt",
+        "max_items",
+        "max_length",
+        "min_items",
+        "min_length",
+        "multiple_of",
+        "regex",
+        "title",
+    ]:
+        value = getattr(field_info, attribute)
+        if value is not None:
+            metadata[attribute] = value
+
+    if (value := field_info.default) not in (PydanticV1Undefined, Ellipsis):
+        metadata["default"] = value
+
+    if value := field.default_factory is not None:
+        metadata["default_factory"] = value
+
+    if not field_info.allow_mutation:
+        metadata["allow_mutation"] = field_info.allow_mutation
+    metadata.update(field_info.extra)
+
+    return MappingProxyType(metadata)

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable, Iterator, KeysView, MutableMapping
 from functools import lru_cache
@@ -132,10 +133,6 @@ class AttrsAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
         self._fields_dict = attr.fields_dict(self.item.__class__)
 
     @classmethod
-    def is_item(cls, item: Any) -> bool:
-        return _is_attrs_class(item) and not isinstance(item, type)
-
-    @classmethod
     def is_item_class(cls, item_class: type) -> bool:
         return _is_attrs_class(item_class)
 
@@ -167,10 +164,6 @@ class DataclassAdapter(_MixinAttrsDataclassAdapter, AdapterInterface):
         super().__init__(item)
         # store a reference to the item's fields to avoid O(n) lookups and O(n^2) traversals
         self._fields_dict = {field.name: field for field in dataclasses.fields(self.item)}
-
-    @classmethod
-    def is_item(cls, item: Any) -> bool:
-        return dataclasses.is_dataclass(item) and not isinstance(item, type)
 
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
@@ -312,10 +305,6 @@ class _MixinDictScrapyItemAdapter:
 
 class DictAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
     @classmethod
-    def is_item(cls, item: Any) -> bool:
-        return isinstance(item, dict)
-
-    @classmethod
     def is_item_class(cls, item_class: type) -> bool:
         return issubclass(item_class, dict)
 
@@ -330,10 +319,6 @@ class DictAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
 
 
 class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
-    @classmethod
-    def is_item(cls, item: Any) -> bool:
-        return isinstance(item, _scrapy_item_classes)
-
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
         return issubclass(item_class, _scrapy_item_classes)
@@ -361,14 +346,39 @@ class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
         return KeysView(self.item.fields)
 
 
+@lru_cache
+def _has_item_overrides(adapter_classes: tuple[type[AdapterInterface], ...]) -> bool:
+    """Return True if any of the given adapter classes overrides is_item(), i.e.
+    decides on an item basis, and hence cannot be matched to an item by item
+    class alone."""
+    base_is_item = AdapterInterface.is_item.__func__  # type: ignore[attr-defined]
+    overriding = [
+        adapter_class
+        for adapter_class in adapter_classes
+        if getattr(adapter_class.is_item, "__func__", adapter_class.is_item) is not base_is_item
+    ]
+    if overriding:
+        names = ", ".join(adapter_class.__qualname__ for adapter_class in overriding)
+        warnings.warn(
+            f"The following adapter classes override the is_item() class method: {names}. "
+            f"Support for that will be removed, and items will then be matched to an "
+            f"adapter class by item class alone. Override is_item_class() instead.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+    return bool(overriding)
+
+
 @lru_cache(maxsize=1024)
 def _find_adapter_class(
     adapter_classes: tuple[type[AdapterInterface], ...], item_class: type
-) -> type[AdapterInterface] | None:
+) -> tuple[type[AdapterInterface] | None, bool]:
+    """Return the first of the given adapter classes that handles the given item
+    class, or None, along with the return value of _has_item_overrides()."""
     for adapter_class in adapter_classes:
         if adapter_class.is_item_class(item_class):
-            return adapter_class
-    return None
+            return adapter_class, _has_item_overrides(adapter_classes)
+    return None, _has_item_overrides(adapter_classes)
 
 
 class ItemAdapter(MutableMapping):
@@ -385,22 +395,36 @@ class ItemAdapter(MutableMapping):
     )
 
     def __init__(self, item: Any) -> None:
-        adapter_class = _find_adapter_class(tuple(self.ADAPTER_CLASSES), item.__class__)
+        adapter_classes = tuple(self.ADAPTER_CLASSES)
+        adapter_class, item_overrides = _find_adapter_class(adapter_classes, item.__class__)
+        if item_overrides:
+            adapter_class = next(
+                (
+                    candidate_class
+                    for candidate_class in adapter_classes
+                    if candidate_class.is_item(item)
+                ),
+                None,
+            )
         if adapter_class is None:
             raise TypeError(f"No adapter found for objects of type: {type(item)} ({item})")
         self.adapter = adapter_class(item)
 
     @classmethod
     def is_item(cls, item: Any) -> bool:
-        return cls.is_item_class(item.__class__)
+        adapter_classes = tuple(cls.ADAPTER_CLASSES)
+        adapter_class, item_overrides = _find_adapter_class(adapter_classes, item.__class__)
+        if item_overrides:
+            return any(adapter_class.is_item(item) for adapter_class in adapter_classes)
+        return adapter_class is not None
 
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
-        return _find_adapter_class(tuple(cls.ADAPTER_CLASSES), item_class) is not None
+        return _find_adapter_class(tuple(cls.ADAPTER_CLASSES), item_class)[0] is not None
 
     @classmethod
     def _get_adapter_class(cls, item_class: type) -> type[AdapterInterface]:
-        adapter_class = _find_adapter_class(tuple(cls.ADAPTER_CLASSES), item_class)
+        adapter_class = _find_adapter_class(tuple(cls.ADAPTER_CLASSES), item_class)[0]
         if adapter_class is None:
             raise TypeError(f"{item_class} is not a valid item class")
         return adapter_class

--- a/itemadapter/adapter.py
+++ b/itemadapter/adapter.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABCMeta, abstractmethod
-from collections import deque
 from collections.abc import Iterable, Iterator, KeysView, MutableMapping
+from functools import lru_cache
 from types import MappingProxyType
 from typing import Any
 
@@ -17,7 +17,7 @@ from itemadapter._json_schema import (
     _setdefault_attribute_docstrings_on_json_schema,
     _setdefault_attribute_types_on_json_schema,
 )
-from itemadapter.utils import (
+from itemadapter._utils import (
     _get_pydantic_model_metadata,
     _get_pydantic_v1_model_metadata,
     _is_attrs_class,
@@ -361,45 +361,49 @@ class ScrapyItemAdapter(_MixinDictScrapyItemAdapter, AdapterInterface):
         return KeysView(self.item.fields)
 
 
+@lru_cache(maxsize=1024)
+def _find_adapter_class(
+    adapter_classes: tuple[type[AdapterInterface], ...], item_class: type
+) -> type[AdapterInterface] | None:
+    for adapter_class in adapter_classes:
+        if adapter_class.is_item_class(item_class):
+            return adapter_class
+    return None
+
+
 class ItemAdapter(MutableMapping):
     """Wrapper class to interact with data container objects. It provides a common interface
     to extract and set data without having to take the object's type into account.
     """
 
-    ADAPTER_CLASSES: Iterable[type[AdapterInterface]] = deque(
-        [
-            ScrapyItemAdapter,
-            DictAdapter,
-            DataclassAdapter,
-            AttrsAdapter,
-            PydanticAdapter,
-        ]
+    ADAPTER_CLASSES: Iterable[type[AdapterInterface]] = (
+        ScrapyItemAdapter,
+        DictAdapter,
+        DataclassAdapter,
+        AttrsAdapter,
+        PydanticAdapter,
     )
 
     def __init__(self, item: Any) -> None:
-        for cls in self.ADAPTER_CLASSES:
-            if cls.is_item(item):
-                self.adapter = cls(item)
-                break
-        else:
+        adapter_class = _find_adapter_class(tuple(self.ADAPTER_CLASSES), item.__class__)
+        if adapter_class is None:
             raise TypeError(f"No adapter found for objects of type: {type(item)} ({item})")
+        self.adapter = adapter_class(item)
 
     @classmethod
     def is_item(cls, item: Any) -> bool:
-        return any(adapter_class.is_item(item) for adapter_class in cls.ADAPTER_CLASSES)
+        return cls.is_item_class(item.__class__)
 
     @classmethod
     def is_item_class(cls, item_class: type) -> bool:
-        return any(
-            adapter_class.is_item_class(item_class) for adapter_class in cls.ADAPTER_CLASSES
-        )
+        return _find_adapter_class(tuple(cls.ADAPTER_CLASSES), item_class) is not None
 
     @classmethod
     def _get_adapter_class(cls, item_class: type) -> type[AdapterInterface]:
-        for adapter_class in cls.ADAPTER_CLASSES:
-            if adapter_class.is_item_class(item_class):
-                return adapter_class
-        raise TypeError(f"{item_class} is not a valid item class")
+        adapter_class = _find_adapter_class(tuple(cls.ADAPTER_CLASSES), item_class)
+        if adapter_class is None:
+            raise TypeError(f"{item_class} is not a valid item class")
+        return adapter_class
 
     @classmethod
     def get_field_meta_from_class(cls, item_class: type, field_name: str) -> MappingProxyType:

--- a/itemadapter/utils.py
+++ b/itemadapter/utils.py
@@ -1,127 +1,13 @@
 from __future__ import annotations
 
-from types import MappingProxyType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from itemadapter._imports import (
-    PydanticUndefined,
-    PydanticV1Undefined,
-    attr,
-    pydantic,
-    pydantic_v1,
-)
+from itemadapter.adapter import ItemAdapter
+
+if TYPE_CHECKING:
+    from types import MappingProxyType
 
 __all__ = ["get_field_meta_from_class", "is_item"]
-
-
-def _is_attrs_class(obj: Any) -> bool:
-    if attr is None:
-        return False
-    return attr.has(obj)
-
-
-def _is_pydantic_model(obj: Any) -> bool:
-    if pydantic is None:
-        return False
-    return issubclass(obj, pydantic.BaseModel)
-
-
-def _is_pydantic_v1_model(obj: Any) -> bool:
-    if pydantic_v1 is None:
-        return False
-    return issubclass(obj, pydantic_v1.BaseModel)
-
-
-def _get_pydantic_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
-    metadata = {}
-    field = item_model.model_fields[field_name]
-
-    for attribute in [
-        "alias_priority",
-        "alias",
-        "allow_inf_nan",
-        "annotation",
-        "coerce_numbers_to_str",
-        "decimal_places",
-        "default_factory",
-        "deprecated",
-        "description",
-        "discriminator",
-        "examples",
-        "exclude",
-        "fail_fast",
-        "field_title_generator",
-        "frozen",
-        "ge",
-        "gt",
-        "init_var",
-        "init",
-        "json_schema_extra",
-        "kw_only",
-        "le",
-        "lt",
-        "max_digits",
-        "max_length",
-        "min_length",
-        "multiple_of",
-        "pattern",
-        "repr",
-        "serialization_alias",
-        "strict",
-        "title",
-        "union_mode",
-        "validate_default",
-        "validation_alias",
-    ]:
-        if hasattr(field, attribute) and (value := getattr(field, attribute)) is not None:
-            metadata[attribute] = value
-
-    for attribute, default_value in [
-        ("default", PydanticUndefined),
-        ("metadata", []),
-    ]:
-        if hasattr(field, attribute) and (value := getattr(field, attribute)) != default_value:
-            metadata[attribute] = value
-
-    return MappingProxyType(metadata)
-
-
-def _get_pydantic_v1_model_metadata(item_model: Any, field_name: str) -> MappingProxyType:
-    metadata = {}
-    field = item_model.__fields__[field_name]
-    field_info = field.field_info
-
-    for attribute in [
-        "alias",
-        "const",
-        "description",
-        "ge",
-        "gt",
-        "le",
-        "lt",
-        "max_items",
-        "max_length",
-        "min_items",
-        "min_length",
-        "multiple_of",
-        "regex",
-        "title",
-    ]:
-        value = getattr(field_info, attribute)
-        if value is not None:
-            metadata[attribute] = value
-
-    if (value := field_info.default) not in (PydanticV1Undefined, Ellipsis):
-        metadata["default"] = value
-
-    if value := field.default_factory is not None:
-        metadata["default_factory"] = value
-
-    if not field_info.allow_mutation:
-        metadata["allow_mutation"] = field_info.allow_mutation
-    metadata.update(field_info.extra)
-
-    return MappingProxyType(metadata)
 
 
 def is_item(obj: Any) -> bool:
@@ -129,8 +15,6 @@ def is_item(obj: Any) -> bool:
 
     Alias for ItemAdapter.is_item
     """
-    from itemadapter.adapter import ItemAdapter
-
     return ItemAdapter.is_item(obj)
 
 
@@ -148,7 +32,4 @@ def get_field_meta_from_class(item_class: type, field_name: str) -> MappingProxy
     The returned value is an instance of types.MappingProxyType, i.e. a dynamic read-only view
     of the original mapping, which gets automatically updated if the original mapping changes.
     """
-
-    from itemadapter.adapter import ItemAdapter
-
     return ItemAdapter.get_field_meta_from_class(item_class, field_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from itemadapter.adapter import _find_adapter_class
+
+
+@pytest.fixture(autouse=True)
+def _clear_adapter_class_cache():
+    """Keep tests that change which item types are supported, e.g. by patching
+    an optional import out, from seeing results cached by earlier tests."""
+    _find_adapter_class.cache_clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from itemadapter.adapter import _find_adapter_class
+from itemadapter.adapter import _find_adapter_class, _has_item_overrides
 
 
 @pytest.fixture(autouse=True)
@@ -8,3 +8,4 @@ def _clear_adapter_class_cache():
     """Keep tests that change which item types are supported, e.g. by patching
     an optional import out, from seeing results cached by earlier tests."""
     _find_adapter_class.cache_clear()
+    _has_item_overrides.cache_clear()

--- a/tests/test_adapter_attrs.py
+++ b/tests/test_adapter_attrs.py
@@ -57,6 +57,7 @@ class AttrsTestCase(unittest.TestCase):
     @mock.patch("builtins.__import__", make_mock_import("attr"))
     def test_module_import_error(self):
         with clear_itemadapter_imports():
+            from itemadapter import utils
             from itemadapter.adapter import AttrsAdapter
 
             assert not AttrsAdapter.is_item(AttrsItem(name="asdf", value=1234))
@@ -67,10 +68,10 @@ class AttrsTestCase(unittest.TestCase):
             with pytest.raises(RuntimeError, match="attr module is not available"):
                 AttrsAdapter.get_field_names_from_class(AttrsItem)
             with pytest.raises(TypeError, match=r"'tests.AttrsItem'\> is not a valid item class"):
-                get_field_meta_from_class(AttrsItem, "name")
+                utils.get_field_meta_from_class(AttrsItem, "name")
 
     @unittest.skipIf(not AttrsItem, "attrs module is not available")
-    @mock.patch("itemadapter.utils.attr", None)
+    @mock.patch("itemadapter._utils.attr", None)
     def test_module_not_available(self):
         from itemadapter.adapter import AttrsAdapter
 

--- a/tests/test_adapter_pydantic.py
+++ b/tests/test_adapter_pydantic.py
@@ -59,17 +59,18 @@ class PydanticTestCase(unittest.TestCase):
     @mock.patch("builtins.__import__", make_mock_import("pydantic"))
     def test_module_import_error(self):
         with clear_itemadapter_imports():
+            from itemadapter import utils
             from itemadapter.adapter import PydanticAdapter
 
             assert not PydanticAdapter.is_item(PydanticModel(name="asdf", value=1234))
             with pytest.raises(
                 TypeError, match=r"tests.PydanticModel'\> is not a valid item class"
             ):
-                get_field_meta_from_class(PydanticModel, "name")
+                utils.get_field_meta_from_class(PydanticModel, "name")
 
     @unittest.skipIf(not PydanticModel, "pydantic module is not available")
-    @mock.patch("itemadapter.utils.pydantic", None)
-    @mock.patch("itemadapter.utils.pydantic_v1", None)
+    @mock.patch("itemadapter._utils.pydantic", None)
+    @mock.patch("itemadapter._utils.pydantic_v1", None)
     def test_module_not_available(self):
         from itemadapter.adapter import PydanticAdapter
 

--- a/tests/test_adapter_pydantic_v1.py
+++ b/tests/test_adapter_pydantic_v1.py
@@ -56,16 +56,17 @@ class PydanticTestCase(unittest.TestCase):
     @mock.patch("builtins.__import__", make_mock_import("pydantic"))
     def test_module_import_error(self):
         with clear_itemadapter_imports():
+            from itemadapter import utils
             from itemadapter.adapter import PydanticAdapter
 
             assert not PydanticAdapter.is_item(PydanticV1Model(name="asdf", value=1234))
             with pytest.raises(
                 TypeError, match=r"tests.PydanticV1Model'\> is not a valid item class"
             ):
-                get_field_meta_from_class(PydanticV1Model, "name")
+                utils.get_field_meta_from_class(PydanticV1Model, "name")
 
-    @mock.patch("itemadapter.utils.pydantic", None)
-    @mock.patch("itemadapter.utils.pydantic_v1", None)
+    @mock.patch("itemadapter._utils.pydantic", None)
+    @mock.patch("itemadapter._utils.pydantic_v1", None)
     def test_module_not_available(self):
         from itemadapter.adapter import PydanticAdapter
 

--- a/tests/test_adapter_scrapy.py
+++ b/tests/test_adapter_scrapy.py
@@ -50,13 +50,14 @@ class ScrapyItemTestCase(unittest.TestCase):
     @mock.patch("builtins.__import__", make_mock_import("scrapy"))
     def test_module_import_error(self):
         with clear_itemadapter_imports():
+            from itemadapter import utils
             from itemadapter.adapter import ScrapyItemAdapter
 
             assert not ScrapyItemAdapter.is_item(ScrapySubclassedItem(name="asdf", value=1234))
             with pytest.raises(
                 TypeError, match=r"tests.ScrapySubclassedItem'\> is not a valid item class"
             ):
-                get_field_meta_from_class(ScrapySubclassedItem, "name")
+                utils.get_field_meta_from_class(ScrapySubclassedItem, "name")
 
     @unittest.skipIf(not ScrapySubclassedItem, "scrapy module is not available")
     @mock.patch("itemadapter.adapter._scrapy_item_classes", ())

--- a/tests/test_itemadapter.py
+++ b/tests/test_itemadapter.py
@@ -1,4 +1,7 @@
 import unittest
+from typing import Any
+
+import pytest
 
 from itemadapter.adapter import DictAdapter, ItemAdapter
 from tests import DataClassItem
@@ -6,6 +9,15 @@ from tests import DataClassItem
 
 class DictOnlyItemAdapter(ItemAdapter):
     ADAPTER_CLASSES = [DictAdapter]
+
+
+class EmptyDictAdapter(DictAdapter):
+    """An adapter that only handles empty dicts, which it can only tell on an
+    item basis."""
+
+    @classmethod
+    def is_item(cls, item: Any) -> bool:
+        return isinstance(item, dict) and not item
 
 
 class ItemAdapterTestCase(unittest.TestCase):
@@ -27,3 +39,14 @@ class ItemAdapterTestCase(unittest.TestCase):
     def test_repr_subclass(self):
         adapter = DictOnlyItemAdapter({"foo": "bar"})
         assert repr(adapter) == "<DictOnlyItemAdapter for dict(foo='bar')>"
+
+    def test_is_item_override(self):
+        class EmptyDictItemAdapter(ItemAdapter):
+            ADAPTER_CLASSES = (EmptyDictAdapter,)
+
+        with pytest.warns(DeprecationWarning, match="EmptyDictAdapter"):
+            assert EmptyDictItemAdapter.is_item({})
+        assert not EmptyDictItemAdapter.is_item({"foo": "bar"})
+        assert isinstance(EmptyDictItemAdapter({}).adapter, EmptyDictAdapter)
+        with pytest.raises(TypeError, match="No adapter found"):
+            EmptyDictItemAdapter({"foo": "bar"})

--- a/tests/test_itemadapter.py
+++ b/tests/test_itemadapter.py
@@ -1,6 +1,7 @@
 import unittest
 
 from itemadapter.adapter import DictAdapter, ItemAdapter
+from tests import DataClassItem
 
 
 class DictOnlyItemAdapter(ItemAdapter):
@@ -11,6 +12,17 @@ class ItemAdapterTestCase(unittest.TestCase):
     def test_repr(self):
         adapter = ItemAdapter({"foo": "bar"})
         assert repr(adapter) == "<ItemAdapter for dict(foo='bar')>"
+
+    def test_adapter_classes_change(self):
+        item = DataClassItem()
+        adapter_classes = ItemAdapter.ADAPTER_CLASSES
+        assert ItemAdapter.is_item(item)
+        ItemAdapter.ADAPTER_CLASSES = (DictAdapter,)
+        try:
+            assert not ItemAdapter.is_item(item)
+        finally:
+            ItemAdapter.ADAPTER_CLASSES = adapter_classes
+        assert ItemAdapter.is_item(item)
 
     def test_repr_subclass(self):
         adapter = DictOnlyItemAdapter({"foo": "bar"})


### PR DESCRIPTION
Resolves https://github.com/scrapy/itemadapter/issues/59

This deprecates the ability to implement `is_item()` with a different outcome for the same item class, and moves towards determining whether an object is an item or not based on its class, and in caching that relation is where we get the savings. Since you usually use the same few item classes during a crawl, those should be serious savings.

The adapter list changes from a `deque` to a `tuple`. Given the official type became `Iterable` in 0.9.0 (2024-05-07), I think that’s fair, and it helps performance-wise.

Post-merge to-do:
- [ ] Update `zyte_common_items.ZyteItemAdapter` accordingly and release a new version of `zyte_common_items` with that change.